### PR TITLE
Freeze dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,6 @@
     "webpack": "1.12.2",
     "webpack-dev-server": "1.12.1"
   },
-  "peerDependencies": {
-    "react": "0.14.8"
-  },
   "dependencies": {
     "react": "15.2.1",
     "react-addons-update": "15.2.1",


### PR DESCRIPTION
`npm install` tells me:

```
npm WARN react-colorpickr@4.2.0 requires a peer of react@0.14.x but none was installed.
npm WARN react-colorpickr@4.2.0 requires a peer of react-dom@0.14.x but none was installed.
```

But everything works for I'm leaving it for now.
