### PR TITLE
keep transformed data per chart type in global store

### DIFF
--- a/app/components/ChartBuilder/index.js
+++ b/app/components/ChartBuilder/index.js
@@ -17,7 +17,7 @@ class ChartBuilder extends AppComponent {
     switch (step) {
       case 1:
         subcomponent = React.createElement(ChartTypeSelector, {
-          data: this.props.state.parsedData,
+          transformedData: this.props.state.transformedData,
           fields: this.props.state.dataFields,
           type: this.props.state.chartOptions.type || '',
         });

--- a/app/components/ChartTypeSelector/index.js
+++ b/app/components/ChartTypeSelector/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { dataTransformers } from '../../constants/dataTransformers';
 import { RECEIVE_CHART_OPTIONS, RECEIVE_CHART_DATA } from '../../constants';
 import actionTrigger from '../../actions';
 import { Radio } from 'rebass';
@@ -11,22 +10,17 @@ class ChartTypeSelector extends Component {
 
   constructor() {
     super();
-    this._testChartTypes = this._testChartTypes.bind(this);
     this._selectChartType = this._selectChartType.bind(this);
     this._renderTypeOption = this._renderTypeOption.bind(this);
   }
 
   componentWillMount() {
-    this._testChartTypes(this.props);
+    if (this.props.type) {
+      this._selectChartType(this.props.type);
+    }
   }
 
-  componentWillReceiveProps(nextProps) {
-    this._testChartTypes(nextProps);
-  }
-
-  _selectChartType(evt) {
-    const type = evt.target.value;
-
+  _selectChartType(type) {
     // send selected chart type  to store options
     this.props.dispatch(actionTrigger(
       RECEIVE_CHART_OPTIONS,
@@ -36,17 +30,8 @@ class ChartTypeSelector extends Component {
     // send data to store, already transformed for selected chart type
     this.props.dispatch(actionTrigger(
       RECEIVE_CHART_DATA,
-      this.state[type]
+      this.props.transformedData[type]
     ));
-  }
-
-  _testChartTypes(props) {
-    const types = Object.keys(dataTransformers);
-    types.forEach((type) =>
-      this.setState({
-        [type]: dataTransformers[type](props.data, props.fields),
-      })
-    );
   }
 
   /**
@@ -54,7 +39,7 @@ class ChartTypeSelector extends Component {
    * and disable chart types where data is incompatible
    */
   _renderTypeOption(type) {
-    const disabled = !this.state[type];
+    const disabled = !this.props.transformedData[type];
     return React.createElement(Radio, {
       key: type,
       circle: true,
@@ -64,7 +49,7 @@ class ChartTypeSelector extends Component {
       backgroundColor: !disabled ? 'primary' : 'secondary',
       disabled,
       checked: (type === this.props.type),
-      onChange: this._selectChartType,
+      onChange: (evt) => this._selectChartType(evt.target.value),
     });
   }
 
@@ -72,7 +57,7 @@ class ChartTypeSelector extends Component {
     return (
       <div>
         <ul className={styles.list}>
-          {Object.keys(this.state).map((type) =>
+          {Object.keys(this.props.transformedData).map((type) =>
             this._renderTypeOption(type)
           )}
         </ul>
@@ -87,7 +72,7 @@ class ChartTypeSelector extends Component {
 }
 
 ChartTypeSelector.propTypes = {
-  data: React.PropTypes.array,
+  transformedData: React.PropTypes.object,
   fields: React.PropTypes.array,
   type: React.PropTypes.string,
   dispatch: React.PropTypes.func,

--- a/app/constants/index.js
+++ b/app/constants/index.js
@@ -20,6 +20,8 @@ export const PARSE_RAW_DATA = 'PARSE_RAW_DATA';
 export const PARSE_DATA_FIELDS = 'PARSE_DATA_FIELDS';
 // error or success from parsing
 export const PARSE_DATA_STATUS = 'PARSE_DATA_STATUS';
+// transform parsed data for chart types
+export const TRANSFORM_DATA = 'TRANSFORM_DATA';
 
 /**
  * Chart rendering actions

--- a/app/reducers/rootReducer.js
+++ b/app/reducers/rootReducer.js
@@ -13,6 +13,7 @@ import chartDataReducer from './chartDataReducer';
 import chartMetadataReducer from './chartMetadataReducer';
 import currentStepReducer from './currentStepReducer';
 import unsavedChangesReducer from './unsavedChangesReducer';
+import transformedDataReducer from './transformedDataReducer';
 
 export default combineReducers({
   rawData: rawDataReducer,
@@ -24,4 +25,5 @@ export default combineReducers({
   chartMetadata: chartMetadataReducer,
   currentStep: currentStepReducer,
   unsavedChanges: unsavedChangesReducer,
+  transformedData: transformedDataReducer,
 });

--- a/app/reducers/transformedDataReducer.js
+++ b/app/reducers/transformedDataReducer.js
@@ -1,0 +1,11 @@
+import { TRANSFORM_DATA } from '../constants';
+
+export default function reducer(state = {}, action) {
+  switch (action.type) {
+    case TRANSFORM_DATA: {
+      return action.data;
+    }
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
Keeping it just in the state of the `ChartTypeSelector` component was causing problems if you added some data, picked a chart type, changed the data, then went back to the `ChartTypeSelector` step - the chart still showed the original data.