### PR TITLE
Settings panels for X and Y axes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 *.log
 *.sh
+*_ignore_*

--- a/app/components/ChartSettings/index.js
+++ b/app/components/ChartSettings/index.js
@@ -5,6 +5,7 @@ class ChartSettings extends Component {
     super();
     this._hasModule = this._hasModule.bind(this);
     this._renderModule = this._renderModule.bind(this);
+    this._shouldDefaultExpand = this._shouldDefaultExpand.bind(this);
   }
 
   componentWillMount() {
@@ -22,7 +23,18 @@ class ChartSettings extends Component {
       return false;
     }
     const module = require(`./modules/${name}`).default;
-    return React.createElement(module, { options: this.props.options });
+    return React.createElement(module, {
+      options: this.props.options,
+      defaultExpand: this._shouldDefaultExpand(),
+    });
+  }
+
+  _shouldDefaultExpand() {
+    let nModules = this.state.modules.length;
+    if (this.props.typeConfig.settingsComponent) {
+      nModules++;
+    }
+    return 1 === nModules;
   }
 
   _renderCustomSettings(config) {
@@ -30,7 +42,10 @@ class ChartSettings extends Component {
       return false;
     }
     const module = require(`./modules/custom/${config.settingsComponent}`).default;
-    return React.createElement(module, { options: this.props.options });
+    return React.createElement(module, {
+      options: this.props.options,
+      defaultExpand: this._shouldDefaultExpand(),
+    });
   }
 
   render() {

--- a/app/components/ChartSettings/modules/Legend.js
+++ b/app/components/ChartSettings/modules/Legend.js
@@ -11,6 +11,7 @@ class Legend extends Component {
       <AccordionBlock
         title="Legend"
         tooltip="Settings for the chart legend"
+        defaultExpand={this.props.defaultExpand}
       >
         <DispatchField
           action={RECEIVE_CHART_OPTIONS_EXTEND}
@@ -28,6 +29,7 @@ class Legend extends Component {
 
 Legend.propTypes = {
   options: React.PropTypes.object,
+  defaultExpand: React.PropTypes.bool,
 };
 
 export default Legend;

--- a/app/components/ChartSettings/modules/Legend.js
+++ b/app/components/ChartSettings/modules/Legend.js
@@ -11,7 +11,6 @@ class Legend extends Component {
       <AccordionBlock
         title="Legend"
         tooltip="Settings for the chart legend"
-        defaultExpand
       >
         <DispatchField
           action={RECEIVE_CHART_OPTIONS_EXTEND}

--- a/app/components/ChartSettings/modules/XAxis.js
+++ b/app/components/ChartSettings/modules/XAxis.js
@@ -5,7 +5,12 @@ import {
   RECEIVE_CHART_OPTIONS_EXTEND,
 } from '../../../constants';
 
-class Legend extends Component {
+class XAxis extends Component {
+
+  _getOptsKey(axisOpts, key, defaultValue = '') {
+    return axisOpts && axisOpts[key] ? axisOpts[key] : defaultValue;
+  }
+
   render() {
     return (
       <AccordionBlock
@@ -19,9 +24,7 @@ class Legend extends Component {
           fieldProps={{
             label: 'Label',
             name: 'xAxis.axisLabel',
-            type: 'number',
-            step: '1',
-            value: this.props.options.xAxis.axisLabel,
+            value: this._getOptsKey(this.props.options.xAxis, 'axisLabel'),
           }}
         />
       </AccordionBlock>
@@ -29,8 +32,8 @@ class Legend extends Component {
   }
 }
 
-Legend.propTypes = {
+XAxis.propTypes = {
   options: React.PropTypes.object,
 };
 
-export default Legend;
+export default XAxis;

--- a/app/components/ChartSettings/modules/XAxis.js
+++ b/app/components/ChartSettings/modules/XAxis.js
@@ -16,7 +16,6 @@ class XAxis extends Component {
       <AccordionBlock
         title="X Axis"
         tooltip="Settings for the X axis"
-        defaultExpand
       >
         <DispatchField
           action={RECEIVE_CHART_OPTIONS_EXTEND}

--- a/app/components/ChartSettings/modules/XAxis.js
+++ b/app/components/ChartSettings/modules/XAxis.js
@@ -22,9 +22,20 @@ class XAxis extends Component {
           action={RECEIVE_CHART_OPTIONS_EXTEND}
           fieldType="Input"
           fieldProps={{
-            label: 'Label',
+            label: 'Axis Label',
             name: 'xAxis.axisLabel',
             value: this._getOptsKey(this.props.options.xAxis, 'axisLabel'),
+          }}
+        />
+
+        <DispatchField
+          action={RECEIVE_CHART_OPTIONS_EXTEND}
+          fieldType="Input"
+          fieldProps={{
+            label: 'Rotate Labels (degrees +/-)',
+            name: 'xAxis.rotateLabels',
+            type: 'number',
+            value: this._getOptsKey(this.props.options.xAxis, 'rotateLabels'),
           }}
         />
       </AccordionBlock>

--- a/app/components/ChartSettings/modules/XAxis.js
+++ b/app/components/ChartSettings/modules/XAxis.js
@@ -1,0 +1,36 @@
+import React, { Component } from 'react';
+import AccordionBlock from '../../Layout/AccordionBlock';
+import DispatchField from '../../lib/DispatchField';
+import {
+  RECEIVE_CHART_OPTIONS_EXTEND,
+} from '../../../constants';
+
+class Legend extends Component {
+  render() {
+    return (
+      <AccordionBlock
+        title="X Axis"
+        tooltip="Settings for the X axis"
+        defaultExpand
+      >
+        <DispatchField
+          action={RECEIVE_CHART_OPTIONS_EXTEND}
+          fieldType="Input"
+          fieldProps={{
+            label: 'Label',
+            name: 'xAxis.axisLabel',
+            type: 'number',
+            step: '1',
+            value: this.props.options.xAxis.axisLabel,
+          }}
+        />
+      </AccordionBlock>
+    );
+  }
+}
+
+Legend.propTypes = {
+  options: React.PropTypes.object,
+};
+
+export default Legend;

--- a/app/components/ChartSettings/modules/XAxis.js
+++ b/app/components/ChartSettings/modules/XAxis.js
@@ -4,6 +4,7 @@ import DispatchField from '../../lib/DispatchField';
 import {
   RECEIVE_CHART_OPTIONS_EXTEND,
 } from '../../../constants';
+import { getObjArrayKey } from '../../../utils/misc';
 
 class XAxis extends Component {
 
@@ -16,6 +17,7 @@ class XAxis extends Component {
       <AccordionBlock
         title="X Axis"
         tooltip="Settings for the X axis"
+        defaultExpand={this.props.defaultExpand}
       >
         <DispatchField
           action={RECEIVE_CHART_OPTIONS_EXTEND}
@@ -23,7 +25,7 @@ class XAxis extends Component {
           fieldProps={{
             label: 'Axis Label',
             name: 'xAxis.axisLabel',
-            value: this._getOptsKey(this.props.options.xAxis, 'axisLabel'),
+            value: getObjArrayKey(this.props.options.xAxis, 'axisLabel'),
           }}
         />
 
@@ -34,7 +36,7 @@ class XAxis extends Component {
             label: 'Rotate Labels (degrees +/-)',
             name: 'xAxis.rotateLabels',
             type: 'number',
-            value: this._getOptsKey(this.props.options.xAxis, 'rotateLabels'),
+            value: getObjArrayKey(this.props.options.xAxis, 'rotateLabels'),
           }}
         />
       </AccordionBlock>
@@ -44,6 +46,7 @@ class XAxis extends Component {
 
 XAxis.propTypes = {
   options: React.PropTypes.object,
+  defaultExpand: React.PropTypes.bool,
 };
 
 export default XAxis;

--- a/app/components/ChartSettings/modules/YAxis.js
+++ b/app/components/ChartSettings/modules/YAxis.js
@@ -1,0 +1,77 @@
+import React, { Component } from 'react';
+import AccordionBlock from '../../Layout/AccordionBlock';
+import DispatchField from '../../lib/DispatchField';
+import {
+  RECEIVE_CHART_OPTIONS_EXTEND,
+} from '../../../constants';
+
+class YAxis extends Component {
+
+  constructor() {
+    super();
+    this._handleYDomain = this._handleYDomain.bind(this);
+  }
+
+  _getOptsKey(axisOpts, key, defaultValue = '') {
+    return axisOpts && axisOpts[key] ? axisOpts[key] : defaultValue;
+  }
+
+  _handleYDomain(fieldProps, value) {
+    let domain = this.props.options.yDomain || [];
+    if ('yDomain.min' === fieldProps.name) {
+      domain[0] = value;
+      return domain;
+    } else if (0 === domain.length) {
+      domain = [0, value];
+    } else {
+      domain[1] = value;
+    }
+    return { yDomain: domain };
+  }
+
+  render() {
+    return (
+      <AccordionBlock title="Y Axis" >
+        <DispatchField
+          action={RECEIVE_CHART_OPTIONS_EXTEND}
+          fieldType="Input"
+          fieldProps={{
+            label: 'Axis Label',
+            name: 'yAxis.axisLabel',
+            value: this._getOptsKey(this.props.options.yAxis, 'axisLabel'),
+          }}
+        />
+        <DispatchField
+          action={RECEIVE_CHART_OPTIONS_EXTEND}
+          fieldType="Input"
+          fieldProps={{
+            label: 'Minimum value',
+            name: 'yDomain.min',
+            type: 'number',
+            step: 'any',
+            value: this._getOptsKey(this.props.options.yDomain, 0),
+          }}
+          handler={this._handleYDomain}
+        />
+        <DispatchField
+          action={RECEIVE_CHART_OPTIONS_EXTEND}
+          fieldType="Input"
+          fieldProps={{
+            label: 'Maximum value',
+            name: 'yDomain.max',
+            type: 'number',
+            step: 'any',
+            value: this._getOptsKey(this.props.options.yDomain, 1),
+          }}
+          handler={this._handleYDomain}
+        />
+      </AccordionBlock>
+    );
+  }
+}
+
+YAxis.propTypes = {
+  options: React.PropTypes.object,
+};
+
+export default YAxis;

--- a/app/components/ChartSettings/modules/YAxis.js
+++ b/app/components/ChartSettings/modules/YAxis.js
@@ -13,7 +13,8 @@ class YAxis extends Component {
   }
 
   _getOptsKey(axisOpts, key, defaultValue = '') {
-    return axisOpts && axisOpts[key] ? axisOpts[key] : defaultValue;
+    return (axisOpts && {}.hasOwnProperty.call(axisOpts, key)) ?
+      axisOpts[key] : defaultValue;
   }
 
   _handleYDomain(fieldProps, value) {

--- a/app/components/ChartSettings/modules/YAxis.js
+++ b/app/components/ChartSettings/modules/YAxis.js
@@ -4,6 +4,7 @@ import DispatchField from '../../lib/DispatchField';
 import {
   RECEIVE_CHART_OPTIONS_EXTEND,
 } from '../../../constants';
+import { getObjArrayKey } from '../../../utils/misc';
 
 class YAxis extends Component {
 
@@ -32,14 +33,17 @@ class YAxis extends Component {
 
   render() {
     return (
-      <AccordionBlock title="Y Axis" >
+      <AccordionBlock
+        title="Y Axis"
+        defaultExpand={this.props.defaultExpand}
+      >
         <DispatchField
           action={RECEIVE_CHART_OPTIONS_EXTEND}
           fieldType="Input"
           fieldProps={{
             label: 'Axis Label',
             name: 'yAxis.axisLabel',
-            value: this._getOptsKey(this.props.options.yAxis, 'axisLabel'),
+            value: getObjArrayKey(this.props.options.yAxis, 'axisLabel'),
           }}
         />
         <DispatchField
@@ -50,7 +54,7 @@ class YAxis extends Component {
             name: 'yDomain.min',
             type: 'number',
             step: 'any',
-            value: this._getOptsKey(this.props.options.yDomain, 0),
+            value: getObjArrayKey(this.props.options.yDomain, 0),
           }}
           handler={this._handleYDomain}
         />
@@ -62,7 +66,7 @@ class YAxis extends Component {
             name: 'yDomain.max',
             type: 'number',
             step: 'any',
-            value: this._getOptsKey(this.props.options.yDomain, 1),
+            value: getObjArrayKey(this.props.options.yDomain, 1),
           }}
           handler={this._handleYDomain}
         />
@@ -73,6 +77,7 @@ class YAxis extends Component {
 
 YAxis.propTypes = {
   options: React.PropTypes.object,
+  defaultExpand: React.PropTypes.bool,
 };
 
 export default YAxis;

--- a/app/components/ChartSettings/modules/custom/PieChartSettings.js
+++ b/app/components/ChartSettings/modules/custom/PieChartSettings.js
@@ -11,7 +11,7 @@ class Legend extends Component {
       <AccordionBlock
         title="Pie Chart Settings"
         tooltip="Specific settings for pie charts"
-        defaultExpand
+        defaultExpand={this.props.defaultExpand}
       >
         <DispatchField
           action={RECEIVE_CHART_OPTIONS_EXTEND}
@@ -29,6 +29,7 @@ class Legend extends Component {
 
 Legend.propTypes = {
   options: React.PropTypes.object,
+  defaultExpand: React.PropTypes.bool,
 };
 
 export default Legend;

--- a/app/components/Layout/AccordionBlock/index.js
+++ b/app/components/Layout/AccordionBlock/index.js
@@ -17,8 +17,7 @@ class AccordionBlock extends Component {
 
   componentWillMount() {
     this.setState({
-      expanded: ('undefined' !== typeof this.props.defaultExpand ||
-        this.props.defaultExpand),
+      expanded: this.props.defaultExpand,
     });
   }
 

--- a/app/components/lib/DispatchField.js
+++ b/app/components/lib/DispatchField.js
@@ -3,12 +3,13 @@ import Rebass from 'rebass';
 import update from 'react-addons-update';
 import { connect } from 'react-redux';
 import actionTrigger from '../../actions';
+import buildDeepObject from '../../utils/buildDeepObject';
 
 class DispatchFields extends Component {
   constructor() {
     super();
     this._handleChange = this._handleChange.bind(this);
-    this._dispatchBool = this._dispatchBool.bind(this);
+    this._dispatchField = this._dispatchField.bind(this);
   }
 
   componentWillMount() {
@@ -26,41 +27,21 @@ class DispatchFields extends Component {
   }
 
   _handleChange(evt) {
+    let fieldValue;
     switch (this.props.fieldType) {
       case 'Checkbox':
+        fieldValue = evt.target.checked;
+        break;
+
       default:
-        this._dispatchBool(evt.target.checked);
+        fieldValue = evt.target.value;
     }
+    this._dispatchField(fieldValue);
   }
 
-  _dispatchBool(checked) {
+  _dispatchField(value) {
     this.props.dispatch(actionTrigger(this.props.action,
-      this._getDispatchObject(this.props.fieldProps.name, checked)));
-  }
-
-  /**
-   * Build a multilevel object from a string like foo.bar.bop into an object like
-   * { foo: { bar: { bop: fieldValue } } }
-   * to use with https://facebook.github.io/react/docs/update.html
-   *
-   * @param string fieldName Use dots to indicate multiple levels for deep merge
-   * @param any fieldValue Value to apply to the deepest level of the name string
-   * @return obj
-   */
-  _getDispatchObject(fieldName, fieldValue) {
-    let dispatchObj;
-    const fieldNameParts = fieldName.split('.');
-
-    // work backwards and construct the object from the inside out
-    fieldNameParts.reverse();
-    fieldNameParts.forEach((part, index) => {
-      if (0 === index) {
-        dispatchObj = { [part]: fieldValue };
-      } else {
-        dispatchObj = { [part]: dispatchObj };
-      }
-    });
-    return dispatchObj;
+      buildDeepObject(this.props.fieldProps.name, value)));
   }
 
   render() {

--- a/app/components/lib/DispatchField.js
+++ b/app/components/lib/DispatchField.js
@@ -28,20 +28,25 @@ class DispatchFields extends Component {
 
   _handleChange(evt) {
     let fieldValue;
-    switch (this.props.fieldType) {
-      case 'Checkbox':
-        fieldValue = evt.target.checked;
-        break;
+    if ('Checkbox' === this.props.fieldType) {
+      fieldValue = evt.target.checked;
+    } else {
+      fieldValue = evt.target.value;
+    }
 
-      default:
-        fieldValue = evt.target.value;
+    // Convert number fields to float or integer
+    if ('number' === evt.target.type) {
+      fieldValue = ('any' === evt.target.step) ?
+        parseFloat(fieldValue, 10) : parseInt(fieldValue, 10);
     }
     this._dispatchField(fieldValue);
   }
 
   _dispatchField(value) {
-    this.props.dispatch(actionTrigger(this.props.action,
-      buildDeepObject(this.props.fieldProps.name, value)));
+    this.props.dispatch(actionTrigger(this.props.action, this.props.handler ?
+      this.props.handler(this.props.fieldProps, value) :
+      buildDeepObject(this.props.fieldProps.name, value)
+    ));
   }
 
   render() {
@@ -57,6 +62,7 @@ DispatchFields.propTypes = {
   action: React.PropTypes.string,
   fieldProps: React.PropTypes.object,
   fieldType: React.PropTypes.string,
+  handler: React.PropTypes.func,
 };
 
 export default connect()(DispatchFields);

--- a/app/constants/chartTypeConfigs/discreteBarChart.js
+++ b/app/constants/chartTypeConfigs/discreteBarChart.js
@@ -4,7 +4,7 @@ export const config = {
   dataFormat: 'nvd3SingleSeries',
   componentName: 'NVD3Adapter',
   modules: {
-    settings: ['XAxis'],
+    settings: ['XAxis', 'YAxis'],
   },
 };
 

--- a/app/constants/chartTypeConfigs/discreteBarChart.js
+++ b/app/constants/chartTypeConfigs/discreteBarChart.js
@@ -4,7 +4,7 @@ export const config = {
   dataFormat: 'nvd3SingleSeries',
   componentName: 'NVD3Adapter',
   modules: {
-    settings: [],
+    settings: ['XAxis'],
   },
 };
 

--- a/app/constants/chartTypeConfigs/lineChart.js
+++ b/app/constants/chartTypeConfigs/lineChart.js
@@ -4,6 +4,6 @@ export const config = {
   dataFormat: 'nvd3MultiSeries',
   componentName: 'NVD3Adapter',
   modules: {
-    settings: [],
+    settings: ['XAxis', 'YAxis'],
   },
 };

--- a/app/constants/chartTypeConfigs/lineChart.js
+++ b/app/constants/chartTypeConfigs/lineChart.js
@@ -4,6 +4,10 @@ export const config = {
   dataFormat: 'nvd3MultiSeries',
   componentName: 'NVD3Adapter',
   modules: {
-    settings: ['XAxis', 'YAxis'],
+    settings: ['XAxis', 'YAxis', 'Legend'],
   },
+};
+
+export const defaultOpts = {
+  showLegend: true,
 };

--- a/app/middleware/selectChartTypeMiddleware.js
+++ b/app/middleware/selectChartTypeMiddleware.js
@@ -7,6 +7,21 @@ import {
 } from '../constants';
 import actionTrigger from '../actions';
 import { getChartTypeDefaultOpts } from '../utils/chartTypeUtils';
+import update from 'react-addons-update';
+import getNiceDomain from '../utils/dataFormats/getNiceDomain';
+
+/**
+ * Need to setup yDomain for NVD3 chart that requires YAXis
+ * unless it's already been set up
+ * @param object chartType Chart type config
+ * @param object storedOptions Current chartOptions in store
+ * @return bool
+ */
+function _shouldSetupYDomain(chartConfig, storedOptions) {
+  return 0 === chartConfig.dataFormat.indexOf('nvd3') &&
+    -1 !== chartConfig.modules.settings.indexOf('YAxis') &&
+    'undefined' === typeof storedOptions.yDomain;
+}
 
 export default function selectChartTypeMiddleware({ getState }) {
   return (dispatch) => (action) => {
@@ -21,21 +36,28 @@ export default function selectChartTypeMiddleware({ getState }) {
     // then select discreteBarChart, you will still see
     // chartOptions.donut === true even though donut is not a relevant
     // option for bar charts
-    const optsAction = (getState().chartOptions.type &&
-      getState().chartOptions.type.length) ?
-      RECEIVE_CHART_OPTIONS : RECEIVE_CHART_OPTIONS_INIT;
-
-    // send default options to store chartOptions
-    dispatch(actionTrigger(optsAction,
-      getChartTypeDefaultOpts(action.data.config.type)));
-
     // use init data action if no data yet
     const dataAction = (0 < getState().chartData.length) ?
       RECEIVE_CHART_DATA : RECEIVE_CHART_DATA_INIT;
 
     // send formatted data to store chartData
-    dispatch(actionTrigger(dataAction,
-      getState().transformedData[action.data.config.dataFormat]));
+    const formattedData = getState()
+      .transformedData[action.data.config.dataFormat];
+    dispatch(actionTrigger(dataAction, formattedData));
+
+    const optsAction = (getState().chartOptions.type &&
+      getState().chartOptions.type.length) ?
+      RECEIVE_CHART_OPTIONS : RECEIVE_CHART_OPTIONS_INIT;
+
+    let chartTypeOpts = getChartTypeDefaultOpts(action.data.config.type);
+    if (_shouldSetupYDomain(action.data.config, getState().chartOptions)) {
+      chartTypeOpts = update(chartTypeOpts, { $merge: {
+        yDomain: getNiceDomain(action.data.config.dataFormat, formattedData),
+      } });
+    }
+
+    // send default options to store chartOptions
+    dispatch(actionTrigger(optsAction, chartTypeOpts));
 
     return dispatch(action);
   };

--- a/app/middleware/selectChartTypeMiddleware.js
+++ b/app/middleware/selectChartTypeMiddleware.js
@@ -51,6 +51,9 @@ export default function selectChartTypeMiddleware({ getState }) {
 
     let chartTypeOpts = getChartTypeDefaultOpts(action.data.config.type);
     if (_shouldSetupYDomain(action.data.config, getState().chartOptions)) {
+      /**
+       * @todo Recalculate yDomain when series visibility is toggled by clicking on dots in the legend
+       */
       chartTypeOpts = update(chartTypeOpts, { $merge: {
         yDomain: getNiceDomain(action.data.config.dataFormat, formattedData),
       } });

--- a/app/utils/buildDeepObject.js
+++ b/app/utils/buildDeepObject.js
@@ -1,0 +1,24 @@
+/**
+ * Build a multilevel object from a string like foo.bar.bop into an object like
+ * { foo: { bar: { bop: value } } }
+ * to use with https://facebook.github.io/react/docs/update.html
+ *
+ * @param string tree Use dots to indicate multiple levels for depth
+ * @param any value Value to apply to the deepest level of the tree
+ * @return obj
+ */
+export default function (treeString, value) {
+  let treeObj;
+  const treeLevels = treeString.split('.');
+
+  // work backwards and construct the object from the inside out
+  treeLevels.reverse();
+  treeLevels.forEach((level, index) => {
+    if (0 === index) {
+      treeObj = { [level]: value };
+    } else {
+      treeObj = { [level]: treeObj };
+    }
+  });
+  return treeObj;
+}

--- a/app/utils/dataFormats/getNiceDomain.js
+++ b/app/utils/dataFormats/getNiceDomain.js
@@ -8,11 +8,8 @@ import { min, max, scale } from 'd3';
  * @return array Range of [min, max] for series
  */
 function _getSeriesDomain(series, format) {
-  const values = [];
   const key = 'nvd3SingleSeries' === format ? 'value' : 'y';
-  series.forEach((point) =>
-    values.push(point[key])
-  );
+  const values = series.reduce((acc, point) => acc.push(point[key]), []);
   return [min(values), max(values)];
 }
 

--- a/app/utils/dataFormats/getNiceDomain.js
+++ b/app/utils/dataFormats/getNiceDomain.js
@@ -1,0 +1,45 @@
+import { min, max, scale } from 'd3';
+
+/**
+ * Get [min, max] array for data series in nvd3SingleSeries or nvd3MultiSeries format
+ *
+ * @param array series Data series
+ * @param string format Data format
+ * @return array Range of [min, max] for series
+ */
+function _getSeriesDomain(series, format) {
+  const values = [];
+  const key = 'nvd3SingleSeries' === format ? 'value' : 'y';
+  series.forEach((point) =>
+    values.push(point[key])
+  );
+  return [min(values), max(values)];
+}
+
+function _getMultiSeriesDomain(series, format) {
+  const mins = [];
+  const maxs = [];
+  series.forEach((singleSeries) => {
+    const domain = _getSeriesDomain(singleSeries.values, format);
+    mins.push(domain[0]);
+    maxs.push(domain[1]);
+  });
+  return [min(mins), max(maxs)];
+}
+
+function _makeNice(range) {
+  return scale.linear().domain(range).nice().domain();
+}
+
+/**
+ * Get "nice" rounded domain from dataset
+ *
+ * @param string format Data format from chart config object
+ * @param array data Chart data transformed for data format
+ * @return array Domain array of [min, max] values
+ */
+export default function getNiceDomain(format, data) {
+  const domain = 'nvd3SingleSeries' === format ?
+    _getSeriesDomain(data, format) : _getMultiSeriesDomain(data, format);
+  return _makeNice(domain);
+}

--- a/app/utils/misc.js
+++ b/app/utils/misc.js
@@ -36,3 +36,14 @@ export function dataIsMultiSeries(data) {
   return ('undefined' !== typeof data[0].key &&
     'undefined' !== typeof data[0].values);
 }
+
+/**
+ * get value from key or default if not set, also works for arrays
+ *
+ * @param obj obj Basic object or array
+ * @param str key Key to look for
+ * @param any defaultValue Default to return if key is not set
+ */
+export function getObjArrayKey(obj, key, defaultValue = '') {
+  return (obj && {}.hasOwnProperty.call(obj, key)) ? obj[key] : defaultValue;
+}


### PR DESCRIPTION
Requires a deep merge into `chartOptions` of something like
```
{
  xAxis: {
    axisLabel: 'The cool axis'
  }
}
```

Also sets up a nicely rounded default `yDomain`