### PR TITLE
Bootstrap and ErrorMessage fixes

### DIFF
--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -26,12 +26,23 @@ export function bootstrapAppData() {
   setupPostMessage();
 
   return function setupReceiveMessage(dispatch) {
-    // Bootstrap chart editor from plugin data
-    receiveMessage('bootstrap.editor', (evt) => {
-      if (evt.data && evt.data.data && Object.keys(evt.data.data).length) {
-        bootstrapStore(dispatch, evt.data.data);
+    /**
+     * Confirm data formatting then bootstrap the store
+     */
+    function _initBootstrap(evt) {
+      if (evt.data &&
+        evt.data.hasOwnProperty('data') &&
+        evt.data.hasOwnProperty('messageType')
+      ) {
+        bootstrapStore(dispatch, evt.data.messageType, evt.data.data);
+      } else {
+        dispatch(actionTrigger(RECEIVE_ERROR, 'e005'));
       }
-    });
+    }
+
+    // Bootstrap chart editor from plugin postMessage
+    receiveMessage('bootstrap.edit', _initBootstrap);
+    receiveMessage('bootstrap.new', _initBootstrap);
 
      // Handle messages from outdated plugin script
     receiveMessage('bootstrap.rawData', () =>

--- a/app/components/App.js
+++ b/app/components/App.js
@@ -24,6 +24,7 @@ class App extends Component {
         chartData: state.chartData,
         chartMetadata: state.chartMetadata,
         chartOptions: state.chartOptions,
+        chartType: state.chartType.config ? state.chartType.config.type : '',
       }),
     });
   }

--- a/app/components/Header/ErrorMessage/ErrorMessage.css
+++ b/app/components/Header/ErrorMessage/ErrorMessage.css
@@ -1,11 +1,15 @@
-:global(.errorMessageContent) {
+.errorMessageContent {
   margin: 0;
-}
 
-:global(.errorMessageContent a) {
-  color: white;
-  &:hover, &:focus {
-    text-decoration: none;
+  p {
+    margin: 0 ;
+  }
+
+  a {
+    color: white;
+    &:hover, &:focus {
+      text-decoration: none;
+    }
   }
 }
 

--- a/app/components/Header/ErrorMessage/index.js
+++ b/app/components/Header/ErrorMessage/index.js
@@ -9,7 +9,7 @@ import actionTrigger from '../../../actions';
 
 class ErrorMessage extends Component {
   render() {
-    if (!this.props.code) {
+    if (!this.props.code && !this.props.children.length) {
       return null;
     }
 
@@ -17,8 +17,11 @@ class ErrorMessage extends Component {
       inverted: true,
       rounded: true,
       theme: 'error',
-      dangerouslySetInnerHTML: getErrorMessage(this.props.code),
     }, { $merge: this.props.override || {} });
+
+    if (this.props.code) {
+      props.dangerouslySetInnerHTML = getErrorMessage(this.props.code);
+    }
 
     const closeErrorMessage = function closeErrorMessage() {
       this.props.dispatch(actionTrigger(CLEAR_ERROR));
@@ -26,7 +29,7 @@ class ErrorMessage extends Component {
 
     return (
       <div className={styles.container}>
-        {React.createElement(Message, props)}
+        {React.createElement(Message, props, this.props.children)}
         <span
           className={styles.closeContainer}
           onClick={closeErrorMessage}
@@ -42,6 +45,7 @@ ErrorMessage.propTypes = {
   override: React.PropTypes.object,
   code: React.PropTypes.string,
   dispatch: React.PropTypes.func,
+  children: React.PropTypes.any.isRequired,
 };
 
 export default connect()(ErrorMessage);

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -56,27 +56,28 @@ class Header extends Component {
     this.setState({ showUnsavedWarning: true });
   }
 
+  /**
+   * Special case since we need to render JSX inside the ErrorMessage component
+   */
   _renderUnsavedWarning() {
     if (!this.state.showUnsavedWarning) {
       return '';
     }
 
-    function discardChanges() {
+    const discardChanges = function discardChanges() {
       sendMessage('closeApp');
       this.setState({ showUnsavedWarning: false });
-    }
-    discardChanges.bind(this);
+    }.bind(this);
 
-    function closeWarning() {
+    const closeWarning = function closeWarning() {
       this.setState({ showUnsavedWarning: false });
-    }
-    closeWarning.bind(this);
+    }.bind(this);
 
     return (
       <ErrorMessage>
         You have unsaved changes.
-        <a href="#" onClick={discardChanges}>Discard changes</a> or
-        <a href="#" onClick={closeWarning}>cancel</a>.
+        <a href="#0" onClick={discardChanges}>Exit without saving</a> or
+        <a href="#0" onClick={closeWarning}>keep working</a>.
       </ErrorMessage>
     );
   }
@@ -110,7 +111,10 @@ class Header extends Component {
             >Exit</Button>
           </div>
         </div>
-        <ErrorMessage code={this.props.errorCode} />
+        {this.props.errorCode ?
+          React.createElement(ErrorMessage, { code: this.props.errorCode }) :
+          this._renderUnsavedWarning()
+        }
       </Fixed>
     );
   }

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -74,9 +74,10 @@ class Header extends Component {
     }.bind(this);
 
     return (
-      <ErrorMessage>
-        You have unsaved changes.
-        <a href="#0" onClick={discardChanges}>Exit without saving</a> or
+      <ErrorMessage code="e000">
+        You have unsaved changes.&nbsp;
+        <a href="#0" onClick={discardChanges}>Exit without saving</a>
+        &nbsp;or&nbsp;
         <a href="#0" onClick={closeWarning}>keep working</a>.
       </ErrorMessage>
     );
@@ -112,7 +113,8 @@ class Header extends Component {
           </div>
         </div>
         {this.props.errorCode ?
-          React.createElement(ErrorMessage, { code: this.props.errorCode }) :
+          React.createElement(
+            ErrorMessage, { code: this.props.errorCode }, false) :
           this._renderUnsavedWarning()
         }
       </Fixed>

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -17,6 +17,7 @@ class Header extends Component {
     this._sequenceSteps = this._sequenceSteps.bind(this);
     this._cancelEdits = this._cancelEdits.bind(this);
     this._renderUnsavedWarning = this._renderUnsavedWarning.bind(this);
+    this._closeUnsavedWarning = this._closeUnsavedWarning.bind(this);
   }
 
   componentWillMount() {
@@ -56,6 +57,13 @@ class Header extends Component {
     this.setState({ showUnsavedWarning: true });
   }
 
+  _closeUnsavedWarning(evt) {
+    if (evt.target.hasAttribute('data-closeApp')) {
+      sendMessage('closeApp');
+    }
+    this.setState({ showUnsavedWarning: false });
+  }
+
   /**
    * Special case since we need to render JSX inside the ErrorMessage component
    */
@@ -64,21 +72,16 @@ class Header extends Component {
       return '';
     }
 
-    const discardChanges = function discardChanges() {
-      sendMessage('closeApp');
-      this.setState({ showUnsavedWarning: false });
-    }.bind(this);
-
-    const closeWarning = function closeWarning() {
-      this.setState({ showUnsavedWarning: false });
-    }.bind(this);
-
     return (
       <ErrorMessage code="e000">
         You have unsaved changes.&nbsp;
-        <a href="#0" onClick={discardChanges}>Exit without saving</a>
+        <a
+          href="#0"
+          data-closeApp
+          onClick={this._closeUnsavedWarning}
+        >Exit without saving</a>
         &nbsp;or&nbsp;
-        <a href="#0" onClick={closeWarning}>keep working</a>.
+        <a href="#0" onClick={this._closeUnsavedWarning}>keep working</a>.
       </ErrorMessage>
     );
   }
@@ -113,8 +116,7 @@ class Header extends Component {
           </div>
         </div>
         {this.props.errorCode ?
-          React.createElement(
-            ErrorMessage, { code: this.props.errorCode }, false) :
+          (<ErrorMessage code={this.props.errorCode}>{false}</ErrorMessage>) :
           this._renderUnsavedWarning()
         }
       </Fixed>

--- a/app/constants/errorCodesMap.js
+++ b/app/constants/errorCodesMap.js
@@ -2,6 +2,7 @@
  * Map error codes to messages. HTML is allowed in messages.
  */
 export default {
+  e000: null, // code for using JSX children instead of stock error message
   e001: 'Data formatting error; see below for details.',
   e002: 'Data field is empty.',
   e003: 'Chart type configuration not found',

--- a/app/middleware/actionLogging.js
+++ b/app/middleware/actionLogging.js
@@ -44,7 +44,7 @@ function _getChangeKind(changeCode) {
       return 'Addition';
 
     case 'D':
-      return 'Deletion';
+      return 'Deletion or key not updated';
 
     case 'E':
       return 'Update';

--- a/app/middleware/receiveChartOptions.js
+++ b/app/middleware/receiveChartOptions.js
@@ -41,19 +41,33 @@ export default function receiveChartType({ getState }) {
       return shouldApply;
     }
 
-    // Apply default palette if we haven't already received colors and we're not receiving them now
-    // @todo Handle non-NVD3 types
+    /**
+     * Was this dispatch triggered by bootstrap.new or bootstrap.edit?
+     */
+    function _actionIsBootstrap() {
+      return 0 === action.src.indexOf('bootstrap');
+    }
+
+    /**
+     * Apply default palette if we haven't already received colors and we're not receiving them now
+     * @todo Handle non-NVD3 types
+     */
     function _shouldApplyDefaultPalette() {
-      return (!nextOpts.color || !nextOpts.color.length) &&
+      return !_actionIsBootstrap() &&
+        (!nextOpts.color || !nextOpts.color.length) &&
         (!getState().chartOptions.color || !getState().chartOptions.color.length); // eslint-disable-line max-len
     }
 
+    /**
+     * return true if we are not bootstrapping from postMessage and
+     * default options not already applied for this chart type
+     */
     function _shouldApplyChartTypeDefaults() {
-      const hasConfig = (getState().chartType.config &&
-        getState().chartType.config.type);
+      const configType = getState().chartType.config ?
+        getState().chartType.config.type : null;
 
-      return (!hasConfig ||
-        getState().chartType.config.type !== getState().defaultsAppliedTo);
+      return !_actionIsBootstrap() &&
+        configType && configType !== getState().defaultsAppliedTo;
     }
 
     /**

--- a/app/middleware/receiveChartOptions.js
+++ b/app/middleware/receiveChartOptions.js
@@ -2,7 +2,10 @@
  * RECEIVE_CHART_OPTIONS middleware
  */
 
-import { RECEIVE_CHART_OPTIONS } from '../constants';
+import {
+  RECEIVE_CHART_OPTIONS,
+  RECEIVE_DEFAULTS_APPLIED_TO,
+} from '../constants';
 import actionTrigger from '../actions';
 import defaultPalette from '../constants/defaultPalette';
 import update from 'react-addons-update';
@@ -79,6 +82,10 @@ export default function receiveChartType({ getState }) {
         nextOpts,
         getState().defaultsAppliedTo
       );
+      dispatch(actionTrigger(
+        RECEIVE_DEFAULTS_APPLIED_TO,
+        getState().chartType.config.type
+      ));
     }
 
     // Apply tick/value formatting

--- a/app/middleware/receiveChartType.js
+++ b/app/middleware/receiveChartType.js
@@ -44,28 +44,31 @@ export default function receiveChartType({ getState }) {
     }
 
     /**
-     * Setup chart type default options
+     * Setup chart type default options if NOT bootstrapping from postMessage
      */
-    let nextOpts = applyChartTypeDefaults(
-      nextConfig,
-      getState().chartOptions,
-      getState().defaultsAppliedTo
-    );
 
-    /**
-     * apply tick/value formatting
-     */
-    nextOpts = applyDataFormatters(nextOpts, nextConfig);
+    if (0 !== action.src.indexOf('bootstrap')) {
+      let nextOpts = applyChartTypeDefaults(
+        nextConfig,
+        getState().chartOptions,
+        getState().defaultsAppliedTo
+      );
 
-    /**
-     * set yDomain if chartData is set up
-     */
-    if (0 < getState().chartData.length) {
-      nextOpts = applyYDomain(nextOpts, nextConfig, getState().chartData);
+      /**
+       * apply tick/value formatting
+       */
+      nextOpts = applyDataFormatters(nextOpts, nextConfig);
+
+      /**
+       * set yDomain if chartData is set up
+       */
+      if (0 < getState().chartData.length) {
+        nextOpts = applyYDomain(nextOpts, nextConfig, getState().chartData);
+      }
+
+      dispatch(actionTrigger(RECEIVE_CHART_OPTIONS, nextOpts));
+      dispatch(actionTrigger(RECEIVE_DEFAULTS_APPLIED_TO, nextConfig.type));
     }
-
-    dispatch(actionTrigger(RECEIVE_CHART_OPTIONS, nextOpts));
-    dispatch(actionTrigger(RECEIVE_DEFAULTS_APPLIED_TO, nextConfig.type));
 
     return dispatch(action);
   };

--- a/app/utils/bootstrapStore.js
+++ b/app/utils/bootstrapStore.js
@@ -84,7 +84,7 @@ export default function bootstrapStore(dispatch, messageType, recdData) {
     { action: actions.RECEIVE_CHART_METADATA, data: recdData.chartMetadata },
   ].forEach((item) => {
     if (undefined !== item.data && Object.keys(item.data).length) {
-      dispatch(actionTrigger(item.action, item.data));
+      dispatch(actionTrigger(item.action, item.data, messageType));
     }
   });
 }

--- a/app/utils/bootstrapStore.js
+++ b/app/utils/bootstrapStore.js
@@ -26,7 +26,7 @@ export default function bootstrapStore(dispatch, messageType, recdData) {
     nextChartType = update(nextChartType, { $set:
       getChartTypeObject(recdData.chartType || recdData.chartOptions.type),
     });
-    if (!nextChartType) {
+    if (!Object.keys(nextChartType).length) {
       // error if missing or misconfigured chart type
       dispatch(actionTrigger(actions.RECEIVE_ERROR, 'e005'));
       return;
@@ -38,13 +38,13 @@ export default function bootstrapStore(dispatch, messageType, recdData) {
    */
 
   /**
-   * Merge saved options into default options to reset
+   * Merge received options into default chart type options to reset
    * any functions that disappeared when object was stringified
    */
   if (!isNewChart) {
     nextOpts = update(
       getChartTypeDefaultOpts(nextChartType.config.type),
-      { $merge: nextChartType }
+      { $merge: nextOpts }
     );
   }
 

--- a/app/utils/bootstrapStore.js
+++ b/app/utils/bootstrapStore.js
@@ -46,6 +46,10 @@ export default function bootstrapStore(dispatch, messageType, recdData) {
       getChartTypeDefaultOpts(nextChartType.config.type),
       { $merge: nextOpts }
     );
+    dispatch(actionTrigger(
+      actions.RECEIVE_DEFAULTS_APPLIED_TO,
+      nextChartType.config.type
+    ));
   }
 
   /**

--- a/app/utils/bootstrapStore.js
+++ b/app/utils/bootstrapStore.js
@@ -10,20 +10,27 @@ import applyDataFormatters from '../middleware/utils/applyDataFormatters';
  * i.e. a chart previously saved in the CMS
  *
  * @param function dispatch Send to Redux
- * @param obj state Saved state as received from parent window
+ * @param string messageType Should be bootstrap.new or bootstrap.edit
+ * @param obj recdData Data received from parent window
  */
-export default function bootstrapStore(dispatch, savedData) {
+export default function bootstrapStore(dispatch, messageType, recdData) {
+  const isNewChart = 'bootstrap.new' === messageType;
+  let nextChartType = {};
+  let nextOpts = update({}, { $set: recdData.chartOptions });
+
   /**
    * Set up chartType config object with
    * fallback to NVD3 options.type for backwards compatibility
    */
-  const nextChartType = update({}, { $set:
-    getChartTypeObject(savedData.chartType || savedData.chartOptions.type),
-  });
-  if (!nextChartType) {
-    // error if missing or misconfigured chart type
-    dispatch(actionTrigger(actions.RECEIVE_ERROR, 'e005'));
-    return;
+  if (!isNewChart) {
+    nextChartType = update(nextChartType, { $set:
+      getChartTypeObject(recdData.chartType || recdData.chartOptions.type),
+    });
+    if (!nextChartType) {
+      // error if missing or misconfigured chart type
+      dispatch(actionTrigger(actions.RECEIVE_ERROR, 'e005'));
+      return;
+    }
   }
 
   /**
@@ -34,10 +41,12 @@ export default function bootstrapStore(dispatch, savedData) {
    * Merge saved options into default options to reset
    * any functions that disappeared when object was stringified
    */
-  let nextOpts = update(
-    getChartTypeDefaultOpts(nextChartType.config.type),
-    { $merge: savedData.chartOptions }
-  );
+  if (!isNewChart) {
+    nextOpts = update(
+      getChartTypeDefaultOpts(nextChartType.config.type),
+      { $merge: nextChartType }
+    );
+  }
 
   /**
    * Reset tick formatting that might also have been deleted
@@ -56,14 +65,22 @@ export default function bootstrapStore(dispatch, savedData) {
   }
 
   /**
-   * Dispatch to store
+   * Dispatch to store when not empty
    */
-  dispatch(actionTrigger(
-    actions.RECEIVE_RAW_DATA, savedData.rawData || ''));
-  dispatch(actionTrigger(
-    actions.RECEIVE_CHART_TYPE, nextChartType));
-  dispatch(actionTrigger(
-    actions.RECEIVE_CHART_OPTIONS, nextOpts));
-  dispatch(actionTrigger(
-    actions.RECEIVE_CHART_METADATA, savedData.chartMetadata || {}));
+  // Handle rawData differently because it's a string
+  if (recdData.rawData && recdData.rawData.length) {
+    dispatch(actionTrigger(
+      actions.RECEIVE_RAW_DATA, recdData.rawData));
+  }
+
+  // If object defined and not empty, dispatch to store
+  [
+    { action: actions.RECEIVE_CHART_OPTIONS, data: nextOpts },
+    { action: actions.RECEIVE_CHART_TYPE, data: nextChartType },
+    { action: actions.RECEIVE_CHART_METADATA, data: recdData.chartMetadata },
+  ].forEach((item) => {
+    if (undefined !== item.data && Object.keys(item.data).length) {
+      dispatch(actionTrigger(item.action, item.data));
+    }
+  });
 }

--- a/app/utils/errorCodeUtils.js
+++ b/app/utils/errorCodeUtils.js
@@ -5,6 +5,5 @@
 import errorCodesMap from '../constants/errorCodesMap';
 
 export default function errorMessageHtml(code) {
-  return { __html:
-    `<p class="errorMessageContent">${errorCodesMap[code] || 'Unknown error.'}</p>` };
+  return { __html: `<p>${errorCodesMap[code] || 'Unknown error.'}</p>` };
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,10 +35,13 @@ var plugins = process.env.DEVELOPMENT ?
   [new webpack.HotModuleReplacementPlugin()] :
   [new WebpackGitHash(gitHashOpts)];
 
+var publicPath = '/static/';
+
 if (process.env.DEVELOPMENT) {
   entry.app.unshift('react-hot-loader/patch');
   entry.app.unshift('webpack/hot/only-dev-server');
   entry.app.unshift('webpack-dev-server/client?http://localhost:8080');
+  publicPath = 'http://localhost:8080' + publicPath;
 }
 
 module.exports = {
@@ -46,7 +49,7 @@ module.exports = {
   entry: entry,
   output: {
     path: path.join(__dirname, 'static'),
-    publicPath: '/static/',
+    publicPath: publicPath,
     filename: process.env.DEVELOPMENT || process.env.JEKYLL ? '[name].js' : '[name].[githash].js',
     chunkFilename: process.env.DEVELOPMENT || process.env.JEKYLL ? '[id].chunk.js' : '[id].[githash].chunk.js'
   },


### PR DESCRIPTION
Fix some stuff related to how Redux middleware handles chart options and chart type when a chart is first set up by parent window.

Also, allow `ErrorMessage` component to accept either an error code which is mapped to a string, or `children` props if you want to give it custom JSX