### PR TITLE
Add static build  to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 *.log
 *.sh
+static


### PR DESCRIPTION
Since we aren't version controlling the static build, perhaps it should be added to `.gitignore`.