### PR TITLE
Add a _new target to the D3 link for better UX

### DIFF
--- a/app/components/ChartDataFormatter/index.js
+++ b/app/components/ChartDataFormatter/index.js
@@ -20,8 +20,9 @@ class ChartDataFormatter extends Component {
     this._applyFormatting = this._applyFormatting.bind(this);
     this.formatGuidelines = [
       'Formatting is applied to y-axis and tooltip labels.',
-      'Learn more about D3 formatting syntax <a href="'
-      + 'https://github.com/d3/d3-format/blob/master/README.md">here</a>.',
+      'Learn more about D3 formatting syntax <a '
+      + 'href="https://github.com/d3/d3-format/blob/master/README.md" '
+      + 'target="_new">here</a>.',
       'Y-axis minimum and maximum range is set under Chart Options',
     ];
   }


### PR DESCRIPTION
Adding `target="_new"` to this D3 doc link will improve UX by not changing page/losing data.

![screen shot 2016-11-04 at 10 07 05 am](https://cloud.githubusercontent.com/assets/1636964/20008328/89c56cde-a276-11e6-97e5-2407d45aca49.png)
