### PR TITLE
Add back country-data and d3-format

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "babel-preset-react": "6.16.0",
     "babel-preset-stage-0": "6.16.0",
     "css-loader": "0.25.0",
+    "country-data": "0.0.31",
+    "d3-format": "1.0.2",
     "eslint": "3.8.1",
     "eslint-config-airbnb": "6.0.2",
     "eslint-loader": "^1.3.0",


### PR DESCRIPTION
In https://github.com/alleyinteractive/simplechart/pull/69, I accidentally dropped a couple packages that @joshkadis had added in https://github.com/alleyinteractive/simplechart/commit/d9e06cf6da9f4887a72509e93b622e16a471aaad#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R28.

See https://github.com/alleyinteractive/simplechart/pull/69#issuecomment-259503998