### PR TITLE
First unit test for Simplechart using Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lint": "eslint src",
     "build": "webpack -p --progress",
     "locales": "node locales.js",
-    "mock-api": "MOCKAPI=true DEVELOPMENT=true ./node_modules/babel-cli/bin/babel-node.js server.js"
+    "mock-api": "MOCKAPI=true DEVELOPMENT=true ./node_modules/babel-cli/bin/babel-node.js server.js",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -16,6 +17,18 @@
   "author": "Josh Kadis",
   "bugs": {
     "url": "https://github.com/alleyinteractive/simplechart-react/issues"
+  },
+  "jest": {
+    "testPathDirs": [
+      "tests"
+    ],
+    "moduleFileExtensions": [
+      "js",
+      "jsx"
+    ],
+    "moduleDirectories": [
+      "node_modules"
+    ]
   },
   "homepage": "https://github.com/alleyinteractive/simplechart-react",
   "devDependencies": {
@@ -36,6 +49,7 @@
     "eslint-plugin-react": "^4.2.3",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
+    "jest": "^17.0.0",
     "lost": "^6.7.2",
     "object.assign": "^4.0.3",
     "postcss": "^5.0.19",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
       "tests"
     ],
     "moduleFileExtensions": [
-      "js",
-      "jsx"
+      "js"
     ],
     "moduleDirectories": [
       "node_modules"

--- a/tests/utils/misc.unit.test.js
+++ b/tests/utils/misc.unit.test.js
@@ -1,0 +1,4 @@
+test('Capitalize test: turns alley into Alley', () => {
+  const utils = require('../../app/utils/misc.js');
+  expect(utils.capitalize('alley')).toBe("Alley");
+});

--- a/tests/utils/misc.unit.test.js
+++ b/tests/utils/misc.unit.test.js
@@ -1,4 +1,4 @@
 test('Capitalize test: turns alley into Alley', () => {
   const utils = require('../../app/utils/misc.js');
-  expect(utils.capitalize('alley')).toBe("Alley");
+  expect(utils.capitalize('alley')).toBe('Alley');
 });


### PR DESCRIPTION
Adds `jest` for unit testing (and possibly integration test in future).

Run `npm install` again and then `npm run test`.