### PR TITLE
Chart title editable on first step

### DIFF
--- a/app/components/App.js
+++ b/app/components/App.js
@@ -64,6 +64,7 @@ class App extends Component {
   _renderAppComponent() {
     if (0 === this.props.state.currentStep) {
       return React.createElement(DataInput, {
+        metadata: this.props.state.chartMetadata,
         rawData: this.props.state.rawData,
         dataStatus: this.props.state.dataStatus,
         dateFormat: this.props.state.dateFormat,

--- a/app/components/DataInput/ChartTitle/ChartTitle.css
+++ b/app/components/DataInput/ChartTitle/ChartTitle.css
@@ -1,0 +1,9 @@
+.container {
+  display: flex;
+  align-items: flex-end;
+  margin-bottom: 15px;
+  :global(.Input) {
+    width: 500px;
+    margin-right: 15px;
+  }
+}

--- a/app/components/DataInput/ChartTitle/index.js
+++ b/app/components/DataInput/ChartTitle/index.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { RECEIVE_CHART_METADATA } from '../../../constants';
 import DispatchField from '../../lib/DispatchField';
 import HelpTrigger from '../../lib/HelpTrigger';
+import * as styles from './ChartTitle.css';
 
 class ChartTitle extends Component {
   constructor() {
@@ -28,7 +29,7 @@ class ChartTitle extends Component {
 
   render() {
     return (
-      <div>
+      <div className={styles.container} >
         <DispatchField
           action={RECEIVE_CHART_METADATA}
           fieldType="Input"
@@ -36,11 +37,11 @@ class ChartTitle extends Component {
             label: 'Chart title',
             name: 'metadata-title',
             value: this.state.title,
-            style: { maxWidth: '500px' },
+            style: { marginBottom: '0px' }, // override default Rebass style
           }}
           handler={this._handleInput}
         />
-        <HelpTrigger docName="chartTitle" />
+        <HelpTrigger docName="chartMetadata" />
       </div>
     );
   }

--- a/app/components/DataInput/ChartTitle/index.js
+++ b/app/components/DataInput/ChartTitle/index.js
@@ -1,0 +1,54 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { RECEIVE_CHART_METADATA } from '../../../constants';
+import DispatchField from '../../lib/DispatchField';
+import HelpTrigger from '../../lib/HelpTrigger';
+
+class ChartTitle extends Component {
+  constructor() {
+    super();
+    this._handleInput = this._handleInput.bind(this);
+  }
+
+  componentWillMount() {
+    this.setState({ title: this.props.metadata.title || '' });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({ title: nextProps.metadata.title || '' });
+  }
+
+  _handleInput(fieldProps, value) {
+    return {
+      title: value,
+      caption: this.props.metadata.caption || '',
+      credit: this.props.metadata.credit || '',
+    };
+  }
+
+  render() {
+    return (
+      <div>
+        <DispatchField
+          action={RECEIVE_CHART_METADATA}
+          fieldType="Input"
+          fieldProps={{
+            label: 'Chart title',
+            name: 'metadata-title',
+            value: this.state.title,
+            style: { maxWidth: '500px' },
+          }}
+          handler={this._handleInput}
+        />
+        <HelpTrigger docName="chartTitle" />
+      </div>
+    );
+  }
+}
+
+ChartTitle.propTypes = {
+  metadata: React.PropTypes.object,
+  dispatch: React.PropTypes.func,
+};
+
+export default connect()(ChartTitle);

--- a/app/components/DataInput/index.js
+++ b/app/components/DataInput/index.js
@@ -9,7 +9,7 @@ import {
 } from '../../constants';
 import { sampleData } from '../../constants/sampleData';
 import actionTrigger from '../../actions';
-import { Heading, Select, Button, Text } from 'rebass';
+import { Label, Heading, Select, Button, Text } from 'rebass';
 import ListBlock from '../Layout/RebassComponents/ListBlock';
 import { appSteps } from '../../constants/appSteps';
 import NextPrevButton from '../Layout/RebassComponents/NextPrevButton';
@@ -126,6 +126,7 @@ class DataInput extends AppComponent {
         <ListBlock list={this.inputRules} />
         <ChartTitle metadata={this.props.metadata} />
         <div>
+          <Label>Chart data</Label>
           <textarea
             id="DataInput"
             className={styles.textarea}

--- a/app/components/DataInput/index.js
+++ b/app/components/DataInput/index.js
@@ -14,6 +14,7 @@ import ListBlock from '../Layout/RebassComponents/ListBlock';
 import { appSteps } from '../../constants/appSteps';
 import NextPrevButton from '../Layout/RebassComponents/NextPrevButton';
 import DateFormatter from './DateFormatter';
+import ChartTitle from './ChartTitle';
 
 class DataInput extends AppComponent {
 
@@ -122,6 +123,7 @@ class DataInput extends AppComponent {
       <div className={this.parentStyles.appComponent}>
         <Heading level={2}>{appSteps[0]}</Heading>
         <ListBlock list={this.inputRules} />
+        <ChartTitle metadata={this.props.metadata} />
         <div>
           <textarea
             id="DataInput"
@@ -180,6 +182,7 @@ class DataInput extends AppComponent {
 
 DataInput.propTypes = {
   rawData: React.PropTypes.string,
+  metadata: React.PropTypes.object,
   dataStatus: React.PropTypes.object,
   dateFormat: React.PropTypes.object,
   firstCol: React.PropTypes.array,

--- a/app/components/DataInput/index.js
+++ b/app/components/DataInput/index.js
@@ -37,6 +37,7 @@ class DataInput extends AppComponent {
       'Enter <em>clean</em> comma-delimited text here.',
       'A header row is required.',
       'See sample data sets for formatting examples',
+      'Chart title is suggested but not required.',
     ];
   }
 

--- a/app/pages/help/chartMetadata.md
+++ b/app/pages/help/chartMetadata.md
@@ -1,0 +1,5 @@
+## Metadata
+
+Metadata – including title, caption, and credit – can be entered in the **Data Input** (title only) or **Settings** steps. These fields will be displayed when the chart is embedded in a post.
+
+Although this metadata is optional *for Simplechart*, your CMS (e.g. WordPress) may require a title before saving the chart in the database. In this case, you may need to enter a post title directly in the CMS before saving the chart, if you have not already added a title in the Simplechart app.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplechart-react",
-  "version": "1.1.0",
+  "version": "1.1.4",
   "description": "Simplechart React",
   "scripts": {
     "start": "DEVELOPMENT=true node server.js",


### PR DESCRIPTION
Surfaces the chart title field when you first load Simplechart. Doing this because a CMS (e.g. WordPress) may require a `post_title` even though Simplechart itself doesn't require a title, and the Metadata input fields on the Settings step were frequently overlooked.

![screen shot 2017-01-12 at 7 02 18 am](https://cloud.githubusercontent.com/assets/997097/21889074/1a405428-d895-11e6-9ba3-df1887a8d155.png)
