### PR TITLE
SC-13 Revision

### DIFF
--- a/app/actions/requestGoogleSheet.js
+++ b/app/actions/requestGoogleSheet.js
@@ -15,7 +15,7 @@ export default function requestGoogleSheet(sheetId) {
       return Promise.resolve();
     }
 
-    dispatch(actionTrigger(REQUEST_GOOGLE_SHEET));
+    dispatch(actionTrigger(REQUEST_GOOGLE_SHEET, sheetId));
 
     const url = buildUrl(parseId(sheetId), googleApiKey);
     const options = {

--- a/app/actions/requestGoogleSheet.js
+++ b/app/actions/requestGoogleSheet.js
@@ -4,7 +4,7 @@ import { RECEIVE_ERROR, RECEIVE_RAW_DATA, REQUEST_GOOGLE_SHEET } from '../consta
 
 /**
  * @param {String} sheetId  A google sheets id, or URL containing an id
- * @return {Promise}
+ * @return {function}
  */
 export default function requestGoogleSheet(sheetId) {
   return (dispatch, getState) => {

--- a/app/components/App.js
+++ b/app/components/App.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import DataInput from './DataInput';
-import update from 'immutability-helper';
 import ChartEditor from './ChartEditor';
 import Header from './Header';
 import Help from './Help';
@@ -13,7 +12,6 @@ class App extends Component {
   constructor() {
     super();
     this._renderAppComponent = this._renderAppComponent.bind(this);
-    this._getSaveData = this._getSaveData.bind(this);
     this._firstParsedCol = this._firstParsedCol.bind(this);
   }
 
@@ -41,21 +39,6 @@ class App extends Component {
     }
   }
 
-  /**
-   * Pluck from state only the keys we want to eventually save to the CMS
-   */
-  _getSaveData() {
-    return update(this.props.state, { $apply: (state) =>
-      ({
-        rawData: state.rawData,
-        chartData: state.chartData,
-        chartMetadata: state.chartMetadata,
-        chartOptions: state.chartOptions,
-        chartType: state.chartType.config ? state.chartType.config.type : '',
-      }),
-    });
-  }
-
   _firstParsedCol() {
     const firstColKey = this.props.state.dataFields[0];
     return this.props.state.parsedData.map((row) => row[firstColKey]);
@@ -81,7 +64,6 @@ class App extends Component {
       // set height 100% so child divs inherit it
       <div style={{ height: '100%' }}>
         <Header
-          saveData={this._getSaveData()}
           currentStep={this.props.state.currentStep}
           unsavedChanges={this.props.state.unsavedChanges}
           errorCode={this.props.state.errorCode}

--- a/app/components/DataInput/index.js
+++ b/app/components/DataInput/index.js
@@ -43,7 +43,7 @@ class DataInput extends AppComponent {
     this.state = {
       rawData: props.rawData,
       sampleDataSet: 0,
-      sheetId: props.googleSheetId,
+      googleSheetId: props.googleSheetId,
     };
 
     this.inputRules = [
@@ -54,9 +54,13 @@ class DataInput extends AppComponent {
     ];
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.rawData !== nextProps.rawData) {
-      this.setState({ rawData: nextProps.rawData });
+  componentWillReceiveProps({ rawData, googleSheetId }) {
+    if (this.props.rawData !== rawData) {
+      this.setState({ rawData });
+    }
+
+    if (this.props.googleSheetId !== googleSheetId) {
+      this.setState({ googleSheetId });
     }
   }
 
@@ -72,7 +76,7 @@ class DataInput extends AppComponent {
   }
 
   _requestSheet() {
-    this.props.dispatch(requestGoogleSheet(this.state.sheetId));
+    this.props.dispatch(requestGoogleSheet(this.state.googleSheetId));
   }
 
   _sampleDataOptions() {
@@ -87,7 +91,7 @@ class DataInput extends AppComponent {
   }
 
   _setSheetId(evt) {
-    this.setState({ sheetId: evt.target.value });
+    this.setState({ googleSheetId: evt.target.value });
   }
 
   _nextCallback(success) {
@@ -146,6 +150,7 @@ class DataInput extends AppComponent {
             name="google-sheets-id"
             onChange={this._setSheetId}
             style={{ marginBottom: 0 }}
+            value={this.state.googleSheetId}
           />
           <HelpTrigger docName="googleSheets" />
         </div>

--- a/app/components/DataInput/index.js
+++ b/app/components/DataInput/index.js
@@ -43,7 +43,7 @@ class DataInput extends AppComponent {
     this.state = {
       rawData: props.rawData,
       sampleDataSet: 0,
-      sheetId: '',
+      sheetId: props.googleSheetId,
     };
 
     this.inputRules = [

--- a/app/components/Header/index.js
+++ b/app/components/Header/index.js
@@ -114,7 +114,6 @@ class Header extends Component {
 
           <div className={styles.actionsContainer}>
             <SaveChart
-              saveData={this.props.saveData}
               buttonStyleAttr={{ marginRight: '10px' }}
               cmsStatus={this.props.cmsStatus}
             />
@@ -136,7 +135,6 @@ class Header extends Component {
 }
 
 Header.propTypes = {
-  saveData: React.PropTypes.object,
   currentStep: React.PropTypes.number,
   dispatch: React.PropTypes.func,
   unsavedChanges: React.PropTypes.bool,

--- a/app/components/SaveChart/index.js
+++ b/app/components/SaveChart/index.js
@@ -6,10 +6,17 @@ import { connect } from 'react-redux';
 import actionTrigger from '../../actions';
 import { UNSAVED_CHANGES } from '../../constants';
 import saveChartLabels from '../../constants/saveChartLabels';
+import { getSaveData } from '../../selectors';
 
 class SaveChart extends Component {
-  constructor() {
-    super();
+  static mapStateToProps(state) {
+    return {
+      saveData: getSaveData(state),
+    };
+  }
+
+  constructor(props) {
+    super(props);
     this._sendDataToParent = this._sendDataToParent.bind(this);
   }
 
@@ -43,4 +50,4 @@ SaveChart.propTypes = {
   dispatch: React.PropTypes.func,
 };
 
-export default connect()(SaveChart);
+export default connect(SaveChart.mapStateToProps)(SaveChart);

--- a/app/constants/index.js
+++ b/app/constants/index.js
@@ -58,9 +58,6 @@ export const RECEIVE_CHART_OPTIONS = 'RECEIVE_CHART_OPTIONS';
 // have default options been applied? if so, for which chart type?
 export const RECEIVE_DEFAULTS_APPLIED_TO = 'RECEIVE_DEFAULTS_APPLIED_TO';
 
-// Deep-extend object into chart options
-export const RECEIVE_CHART_OPTIONS_EXTEND = 'RECEIVE_CHART_OPTIONS_EXTEND';
-
 // chart metadata
 export const RECEIVE_CHART_METADATA = 'RECEIVE_CHART_METADATA';
 

--- a/app/index.js
+++ b/app/index.js
@@ -19,24 +19,29 @@ import { bootstrapAppData } from './actions';
 import App from './components/App';
 import { sendMessage } from './utils/postMessage';
 import * as NVD3Styles from '!!style-loader!raw-loader!nvd3/build/nv.d3.css'; // eslint-disable-line no-unused-vars
-import rootReducer from './reducers/rootReducer';
+import rootReducer, { initialState } from './reducers/rootReducer';
 import getPublicPath from './utils/getPublicPath';
 
 // Set public path for loading chunks and other assets
 __webpack_public_path__ = __webpack_public_path__ || getPublicPath(); // eslint-disable-line camelcase,no-undef
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-const store = createStore(rootReducer, composeEnhancers(
-  applyMiddleware(
-    thunk,
-    receiveRawData,
-    receiveDateFormat,
-    receiveChartType,
-    receiveChartOptions,
-    receiveHelpDocument,
-    actionLogging
+
+const store = createStore(
+  rootReducer,
+  initialState,
+  composeEnhancers(
+    applyMiddleware(
+      thunk,
+      receiveRawData,
+      receiveDateFormat,
+      receiveChartType,
+      receiveChartOptions,
+      receiveHelpDocument,
+      actionLogging
+    )
   )
-));
+);
 
 store.dispatch(bootstrapAppData());
 

--- a/app/reducers/bootstrapReducer.js
+++ b/app/reducers/bootstrapReducer.js
@@ -10,5 +10,8 @@ export default function bootstrapReducer(state = {}, action) {
     googleApiKey: {
       $set: action.data.googleApiKey,
     },
+    googleSheetId: {
+      $set: action.data.googleSheetId,
+    },
   });
 }

--- a/app/reducers/genericReducers.js
+++ b/app/reducers/genericReducers.js
@@ -4,6 +4,9 @@ import update from 'immutability-helper';
 import cloneDeep from 'lodash/cloneDeep';
 
 /**
+ * Create a generic reducer that takes the action data payload and applies it directly to the
+ * state with an immutability helper command.
+ *
  * @param {string} command - An immutability helper command to apply to the state object property.
  * @param {object} actionMap - A map of action types to state object properties.
  * @param {function} [resolveValue] - A callback to resolve the value, otherwise the action data

--- a/app/reducers/rootReducer.js
+++ b/app/reducers/rootReducer.js
@@ -23,6 +23,7 @@ export const initialState = {
   dataStatus: {},
   errorCode: '',
   googleApiKey: null,
+  googleSheetId: null,
   helpDocument: '',
   parsedData: [],
   rawData: '',
@@ -43,6 +44,7 @@ const setActionReducer = createGenericReducer('$set', {
   [actions.PARSE_RAW_DATA]: 'parsedData',
   [actions.RECEIVE_RAW_DATA]: 'rawData',
   [actions.TRANSFORM_DATA]: 'transformedData',
+  [actions.REQUEST_GOOGLE_SHEET]: 'googleSheetId',
 });
 
 const clearActionMap = {

--- a/app/reducers/rootReducer.js
+++ b/app/reducers/rootReducer.js
@@ -2,42 +2,69 @@
  * Combine all reducers in this file and export the combined reducers.
  * If we were to do this in store.js, reducers wouldn't be hot reloadable.
  */
-import { combineReducers } from 'redux';
-import { baseReducer, mergeReducer, createComposedReducer } from './genericReducers';
+import { createGenericReducer, createComposedReducer } from './genericReducers';
 import chartOptionsReducer from './chartOptionsReducer';
-import setClearReducer from './setClearReducer';
 import chartDataReducer from './chartDataReducer';
 import rawDataReducer from './rawDataReducer';
 import unsavedChangesReducer from './unsavedChangesReducer';
 import bootstrapReducer from './bootstrapReducer';
 import * as actions from '../constants';
 
-// TODO: Refactor this into something simpler.
-// Because the state design is significantly interdependent, combinedReducers (state slices) isn't very useful.
-const defaultReducer = combineReducers({
-  chartData: baseReducer([], []),
-  chartMetadata: baseReducer({}, [actions.RECEIVE_CHART_METADATA]),
-  chartOptions: baseReducer({}, []),
-  chartType: baseReducer({}, [actions.RECEIVE_CHART_TYPE]),
-  cmsStatus: baseReducer('', [actions.RECEIVE_CMS_STATUS]),
-  currentStep: baseReducer(0, [actions.UPDATE_CURRENT_STEP]),
-  dateFormat: mergeReducer({}, [actions.RECEIVE_DATE_FORMAT]),
-  defaultsAppliedTo: baseReducer('', [actions.RECEIVE_DEFAULTS_APPLIED_TO]),
-  dataFields: baseReducer([], [actions.PARSE_DATA_FIELDS]),
-  dataStatus: baseReducer({}, [actions.PARSE_DATA_STATUS]),
-  errorCode: setClearReducer('',
-    actions.RECEIVE_ERROR, actions.CLEAR_ERROR),
-  googleApiKey: baseReducer(null, []),
-  helpDocument: setClearReducer('',
-    actions.RECEIVE_HELP_DOCUMENT, actions.CLEAR_HELP_DOCUMENT),
-  parsedData: baseReducer([], [actions.PARSE_RAW_DATA]),
-  rawData: baseReducer('', [actions.RECEIVE_RAW_DATA]),
-  transformedData: baseReducer({}, [actions.TRANSFORM_DATA]),
-  unsavedChanges: unsavedChangesReducer,
+export const initialState = {
+  chartData: [],
+  chartMetadata: {},
+  chartOptions: {},
+  chartType: {},
+  cmsStatus: '',
+  currentStep: 0,
+  dateFormat: {},
+  defaultsAppliedTo: '',
+  dataFields: [],
+  dataStatus: {},
+  errorCode: '',
+  googleApiKey: null,
+  helpDocument: '',
+  parsedData: [],
+  rawData: '',
+  transformedData: {},
+  unsavedChanges: false,
+};
+
+const setActionReducer = createGenericReducer('$set', {
+  [actions.RECEIVE_CHART_METADATA]: 'chartMetadata',
+  [actions.RECEIVE_CHART_TYPE]: 'chartType',
+  [actions.RECEIVE_CMS_STATUS]: 'cmsStatus',
+  [actions.UPDATE_CURRENT_STEP]: 'currentStep',
+  [actions.RECEIVE_DEFAULTS_APPLIED_TO]: 'defaultsAppliedTo',
+  [actions.PARSE_DATA_FIELDS]: 'dataField',
+  [actions.PARSE_DATA_STATUS]: 'dataStatus',
+  [actions.RECEIVE_ERROR]: 'errorCode',
+  [actions.RECEIVE_HELP_DOCUMENT]: 'helpDocument',
+  [actions.PARSE_RAW_DATA]: 'parsedData',
+  [actions.RECEIVE_RAW_DATA]: 'rawData',
+  [actions.TRANSFORM_DATA]: 'transformedData',
+});
+
+const clearActionMap = {
+  [actions.CLEAR_ERROR]: 'errorCode',
+  [actions.CLEAR_HELP_DOCUMENT]: 'helpDocument',
+};
+
+const clearActionReducer = createGenericReducer(
+  '$set',
+  clearActionMap,
+  (data, property) => initialState[property]
+);
+
+const mergeActionReducer = createGenericReducer('$merge', {
+  [actions.RECEIVE_DATE_FORMAT]: 'dateFormat',
 });
 
 export default createComposedReducer([
-  defaultReducer,
+  setActionReducer,
+  clearActionReducer,
+  mergeActionReducer,
+  unsavedChangesReducer,
   bootstrapReducer,
   rawDataReducer,
   chartDataReducer,

--- a/app/reducers/unsavedChangesReducer.js
+++ b/app/reducers/unsavedChangesReducer.js
@@ -8,7 +8,7 @@ export default function unsavedChangesReducer(state = {}, action) {
   let value = state.unsavedChanges;
 
   if (chartChanged) {
-    value = false;
+    value = true;
   } else if (type === UNSAVED_CHANGES) {
     value = data;
   }

--- a/app/reducers/unsavedChangesReducer.js
+++ b/app/reducers/unsavedChangesReducer.js
@@ -1,17 +1,21 @@
+import update from 'immutability-helper';
 import { CHART_UPDATE_ACTIONS, UNSAVED_CHANGES } from '../constants';
 
-export default function unsavedChangesReducer(state = false, action) {
+export default function unsavedChangesReducer(state = {}, action) {
   const { type, src, data } = action;
   const chartChanged = -1 < CHART_UPDATE_ACTIONS.indexOf(type) &&
     -1 === src.indexOf('bootstrap');
+  let value = state.unsavedChanges;
 
   if (chartChanged) {
-    return true;
+    value = false;
+  } else if (type === UNSAVED_CHANGES) {
+    value = data;
   }
 
-  if (type === UNSAVED_CHANGES) {
-    return data;
-  }
-
-  return state;
+  return update(state, {
+    unsavedChanges: {
+      $set: value,
+    },
+  });
 }

--- a/app/selectors/index.js
+++ b/app/selectors/index.js
@@ -1,3 +1,4 @@
+import pick from 'lodash/fp/pick';
 import { createSelector } from 'reselect';
 
 const checkDataValid = createSelector(
@@ -36,3 +37,18 @@ export const getIsNextStepAvailable = createSelector(
     }
   }
 );
+
+export const getSaveData = (state) => {
+  // Pluck from state only the keys we want to eventually save to the CMS
+  const properties = [
+    'rawData',
+    'chartData',
+    'chartMetadata',
+    'chartOptions',
+    'googleSheetId',
+  ];
+
+  return Object.assign(pick(properties, state), {
+    chartType: state.chartType.config ? state.chartType.config.type : '',
+  });
+};

--- a/app/utils/bootstrapStore.js
+++ b/app/utils/bootstrapStore.js
@@ -30,8 +30,6 @@ export default function bootstrapStore(dispatch, messageType, recdData) {
 
   // TODO: Most of the logic in this file should live in a reducer.
   // Refactor towards a centralized "bootstrap" action.
-
-  // Need to setup googleSheetId to exist in cms rehydration process.
   dispatch(actionTrigger(BOOTSTRAP_APP, recdData, messageType));
 
   /**

--- a/app/utils/bootstrapStore.js
+++ b/app/utils/bootstrapStore.js
@@ -30,6 +30,8 @@ export default function bootstrapStore(dispatch, messageType, recdData) {
 
   // TODO: Most of the logic in this file should live in a reducer.
   // Refactor towards a centralized "bootstrap" action.
+
+  // Need to setup googleSheetId to exist in cms rehydration process.
   dispatch(actionTrigger(BOOTSTRAP_APP, recdData, messageType));
 
   /**

--- a/tests/actions/requestGoogleSheet.integration.test.js
+++ b/tests/actions/requestGoogleSheet.integration.test.js
@@ -22,17 +22,19 @@ beforeEach(() => {
 const mockSheetId = 'abc123';
 const mockApiKey = 'fooBarBaz456';
 
-test('dispatches error if no api key in state', () => {
+test('dispatches error if no api key in state', (done) => {
   getState.mockReturnValue({});
 
   const thunk = requestGoogleSheet(mockSheetId);
   thunk(dispatch, getState).then(() => {
     expect(dispatch)
       .toHaveBeenCalledWith(actionTrigger(RECEIVE_ERROR, 'e009'));
+
+    done();
   });
 });
 
-test('handles request to fetch sheet data', () => {
+test('handles request to fetch sheet data', (done) => {
   const mockCSV = `Group,Count\nGroup A,3\n`;
   const mockResponse = {
     status: '200',
@@ -60,11 +62,13 @@ test('handles request to fetch sheet data', () => {
       .toHaveBeenCalledWith(actionTrigger(RECEIVE_RAW_DATA, mockCSV));
 
     expect(dispatch)
-      .toHaveBeenCalledWith(actionTrigger(REQUEST_GOOGLE_SHEET));
+      .toHaveBeenCalledWith(actionTrigger(REQUEST_GOOGLE_SHEET, mockSheetId));
+
+    done();
   });
 });
 
-test('dispatches error if sheet request fails', () => {
+test('dispatches error if sheet request fails', (done) => {
   getState.mockReturnValue({ googleApiKey: mockApiKey });
 
   fetch.mockImplementation(() => Promise.resolve({ status: '500' }));
@@ -73,5 +77,7 @@ test('dispatches error if sheet request fails', () => {
   thunk(dispatch, getState).then(() => {
     expect(dispatch)
       .toHaveBeenCalledWith(actionTrigger(RECEIVE_ERROR, 'e010'));
+
+    done();
   });
 });

--- a/tests/reducers/bootstrapReducer.unit.test.js
+++ b/tests/reducers/bootstrapReducer.unit.test.js
@@ -1,0 +1,19 @@
+import { BOOTSTRAP_APP } from '../../app/constants';
+import { initialState } from '../../app/reducers/rootReducer';
+import reduce from '../../app/reducers/bootstrapReducer';
+
+test('hydrates app state', () => {
+  const action = {
+    type: BOOTSTRAP_APP,
+    data: {
+      googleApiKey: 'fooBarBaz1234',
+      googleSheetId: 'IdFoo456',
+    },
+    src: 'bootstrap.new',
+  };
+
+  expect(reduce(initialState, action)).toMatchObject({
+    googleApiKey: 'fooBarBaz1234',
+    googleSheetId: 'IdFoo456',
+  });
+});

--- a/tests/reducers/unsavedChanges.unit.test.js
+++ b/tests/reducers/unsavedChanges.unit.test.js
@@ -1,17 +1,19 @@
 import { RECEIVE_RAW_DATA, UNSAVED_CHANGES } from '../../app/constants';
 import reduce from '../../app/reducers/unsavedChangesReducer';
 
+const initialState = { unsavedChanges: false };
+
 test('sets state', () => {
   const action = { type: UNSAVED_CHANGES, data: true };
-  expect(reduce(false, action)).toBe(true);
+  expect(reduce(initialState, action).unsavedChanges).toBe(true);
 });
 
 test('sets state to true for chart modifying actions', () => {
   const action = { type: RECEIVE_RAW_DATA, src: '' };
-  expect(reduce(false, action)).toBe(true);
+  expect(reduce(initialState, action).unsavedChanges).toBe(true);
 });
 
 test('filters bootstrap actions', () => {
   const action = { type: RECEIVE_RAW_DATA, src: 'bootstrap.new' };
-  expect(reduce(false, action)).toBe(false);
+  expect(reduce(initialState, action).unsavedChanges).toBe(false);
 });

--- a/tests/selectors/index.test.js
+++ b/tests/selectors/index.test.js
@@ -1,4 +1,5 @@
-import { getIsNextStepAvailable } from '../../app/selectors';
+import { initialState } from '../../app/reducers/rootReducer';
+import { getIsNextStepAvailable, getSaveData } from '../../app/selectors';
 
 const validState = {
   currentStep: 0,
@@ -43,4 +44,14 @@ describe('getIsNextStepAvailable', () => {
 
     expect(getIsNextStepAvailable(state)).toBe(false);
   });
+});
+
+test('getSaveData prunes app state to a shape ready for persistence', () => {
+  const result = getSaveData(initialState);
+  expect(result).toHaveProperty('rawData');
+  expect(result).toHaveProperty('chartData');
+  expect(result).toHaveProperty('chartMetadata');
+  expect(result).toHaveProperty('chartOptions');
+  expect(result).toHaveProperty('googleSheetId');
+  expect(result).toHaveProperty('chartType', '');
 });


### PR DESCRIPTION
https://alleyinteractive.atlassian.net/browse/SC-13

- Store the entered google sheet Id into the app state, and persist it to the CMS with the postMessageAPI, so that the user can refresh the sheet data when they reload the chart in the application.
- Refactor away combine reducers, so that all reducers consistently work with the entire state object.

Here is an example bootstrap message you can paste into dev tools console to test this PR.

```
window.parent.postMessage({messageType: 'bootstrap.new', data: {
  'rawData': '',
  'chartData': [],
  'chartMetadata': {},
  'chartOptions': {},
  'chartType': '',
  'googleApiKey': 'AIzaSyAF1O7lIB1iwW1QaefyS-QUZw1tTWFr2Hc',
  'googleSheetId': '1I-HG3vfDo7ZLRUK_rBLuEexxpOplOhQsK_dgckK2wIc'
}}, '*');
```

