### PR TITLE
SC-115

### DIFF
--- a/app/components/ChartEditor/index.js
+++ b/app/components/ChartEditor/index.js
@@ -81,6 +81,7 @@ export default class ChartEditor extends AppComponent {
     return (
       <div className={styles.chartContainer} style={{ width, left }}>
         <h3>{state.chartMetadata.title}</h3>
+        <h2>{state.chartMetaData.subtitle}</h2>
         <Chart
           data={state.chartData}
           options={state.chartOptions}

--- a/app/components/ChartEditor/index.js
+++ b/app/components/ChartEditor/index.js
@@ -81,7 +81,7 @@ export default class ChartEditor extends AppComponent {
     return (
       <div className={styles.chartContainer} style={{ width, left }}>
         <h3>{state.chartMetadata.title}</h3>
-        <h2>{state.chartMetaData.subtitle}</h2>
+        <h4>{state.chartMetadata.subtitle}</h4>
         <Chart
           data={state.chartData}
           options={state.chartOptions}

--- a/app/components/ChartSettings/modules/Metadata.js
+++ b/app/components/ChartSettings/modules/Metadata.js
@@ -23,7 +23,8 @@ export default class Metadata extends Component {
 
   componentWillMount() {
     this.setState(this.props.metadata);
-    if (false !== this.props.metadata.subtitle) {
+    if ('undefined' !== typeof this.props.metadata.subtitle &&
+      false !== this.props.metadata.subtitle) {
       this.shouldShowMetadata.subtitle = true;
     }
   }

--- a/app/components/ChartSettings/modules/Metadata.js
+++ b/app/components/ChartSettings/modules/Metadata.js
@@ -18,6 +18,7 @@ export default class Metadata extends Component {
     title: '',
     caption: '',
     credit: '',
+    subtitle: '',
   };
 
   componentWillMount() {
@@ -42,7 +43,7 @@ export default class Metadata extends Component {
     return (
       <AccordionBlock
         title="Metadata"
-        tooltip="Title, caption, credit"
+        tooltip="Title, subtitle, caption, credit"
         defaultExpand={this.props.defaultExpand}
       >
         {Object.keys(this.state).map((key) =>

--- a/app/components/ChartSettings/modules/Metadata.js
+++ b/app/components/ChartSettings/modules/Metadata.js
@@ -6,7 +6,7 @@ import DispatchField from '../../lib/DispatchField';
 import {
   RECEIVE_CHART_METADATA,
 } from '../../../constants';
-import { getObjArrayKey, capitalize } from '../../../utils/misc';
+import { getObjArrayKeyStringOnly, capitalize } from '../../../utils/misc';
 
 export default class Metadata extends Component {
   static propTypes = {
@@ -18,15 +18,25 @@ export default class Metadata extends Component {
     title: '',
     caption: '',
     credit: '',
-    subtitle: '',
+    subtitle: false,
   };
 
   componentWillMount() {
     this.setState(this.props.metadata);
+    if (false !== this.props.metadata.subtitle) {
+      this.shouldShowMetadata.subtitle = true;
+    }
   }
 
   componentWillReceiveProps(nextProps) {
     this.setState(nextProps.metadata);
+  }
+
+  shouldShowMetadata = {
+    title: true,
+    caption: true,
+    credit: true,
+    subtitle: false,
   }
 
   handler = (fieldProps, value) => {
@@ -40,6 +50,9 @@ export default class Metadata extends Component {
   };
 
   render() {
+    if (!this.shouldShowMetadata.subtitle) {
+      delete this.state.subtitle;
+    }
     return (
       <AccordionBlock
         title="Metadata"
@@ -55,7 +68,7 @@ export default class Metadata extends Component {
                 fieldProps={{
                   label: capitalize(key),
                   name: key,
-                  value: getObjArrayKey(this.state, key, ''),
+                  value: getObjArrayKeyStringOnly(this.state, key, ''),
                 }}
                 handler={this.handler}
               />

--- a/app/components/ChartSettings/modules/Metadata.js
+++ b/app/components/ChartSettings/modules/Metadata.js
@@ -54,9 +54,6 @@ export default class Metadata extends Component {
   };
 
   render() {
-    if (!this.shouldShowMetadata.subtitle) {
-      delete this.state.subtitle;
-    }
     return (
       <AccordionBlock
         title="Metadata"

--- a/app/components/ChartSettings/modules/Metadata.js
+++ b/app/components/ChartSettings/modules/Metadata.js
@@ -21,23 +21,26 @@ export default class Metadata extends Component {
     subtitle: false,
   };
 
+  /* eslint-disable react/sort-comp */
+  shouldShowMetadata = {
+    title: true,
+    caption: true,
+    credit: true,
+    subtitle: false,
+  }
+  /* eslint-enable react/sort-comp */
+
   componentWillMount() {
     this.setState(this.props.metadata);
     if ('undefined' !== typeof this.props.metadata.subtitle &&
-      false !== this.props.metadata.subtitle) {
+      ('' === this.props.metadata.subtitle || this.props.metadata.subtitle)
+    ) {
       this.shouldShowMetadata.subtitle = true;
     }
   }
 
   componentWillReceiveProps(nextProps) {
     this.setState(nextProps.metadata);
-  }
-
-  shouldShowMetadata = {
-    title: true,
-    caption: true,
-    credit: true,
-    subtitle: false,
   }
 
   handler = (fieldProps, value) => {
@@ -57,25 +60,28 @@ export default class Metadata extends Component {
     return (
       <AccordionBlock
         title="Metadata"
-        tooltip="Title, subtitle, caption, credit"
+        tooltip="Title and other metadata fields"
         defaultExpand={this.props.defaultExpand}
       >
-        {Object.keys(this.state).map((key) =>
-          (
-            <div key={`metadata-${key}`}>
-              <DispatchField
-                action={RECEIVE_CHART_METADATA}
-                fieldType="Input"
-                fieldProps={{
-                  label: capitalize(key),
-                  name: key,
-                  value: getObjArrayKeyStringOnly(this.state, key, ''),
-                }}
-                handler={this.handler}
-              />
-            </div>
-          )
-        )}
+        {Object.keys(this.state).map((key) => {
+          if (this.shouldShowMetadata[key]) {
+            return (
+              <div key={`metadata-${key}`}>
+                <DispatchField
+                  action={RECEIVE_CHART_METADATA}
+                  fieldType="Input"
+                  fieldProps={{
+                    label: capitalize(key),
+                    name: key,
+                    value: getObjArrayKeyStringOnly(this.state, key, ''),
+                  }}
+                  handler={this.handler}
+                />
+              </div>
+            );
+          }
+          return '';
+        })}
       </AccordionBlock>
     );
   }

--- a/app/components/DataInput/ChartTitle/index.js
+++ b/app/components/DataInput/ChartTitle/index.js
@@ -23,6 +23,7 @@ class ChartTitle extends Component {
     title: value,
     caption: this.props.metadata.caption || '',
     credit: this.props.metadata.credit || '',
+    subtitle: this.props.metadata.subtitle || false,
   });
 
   render() {

--- a/app/pages/help/chartMetadata.md
+++ b/app/pages/help/chartMetadata.md
@@ -1,5 +1,5 @@
 ## Metadata
 
-Metadata – including title, caption, and credit – can be entered in the **Data Input** (title only) or **Settings** steps. These fields will be displayed when the chart is embedded in a post.
+Metadata – including title, subtitle, caption, and credit – can be entered in the **Data Input** (title only) or **Settings** steps. These fields will be displayed when the chart is embedded in a post.
 
 Although this metadata is optional *for Simplechart*, your CMS (e.g. WordPress) may require a title before saving the chart in the database. In this case, you may need to enter a post title directly in the CMS before saving the chart, if you have not already added a title in the Simplechart app.

--- a/app/pages/help/chartMetadata.md
+++ b/app/pages/help/chartMetadata.md
@@ -1,5 +1,5 @@
 ## Metadata
 
-Metadata – including title, subtitle, caption, and credit – can be entered in the **Data Input** (title only) or **Settings** steps. These fields will be displayed when the chart is embedded in a post.
+Metadata – including title, subtitle, caption, and credit – can be entered in the **Data Input** (title only) or **Settings** steps. These fields will be displayed when the chart is embedded in a post. The subtitle field is disabled by default and can be enabled by site-specific setup.
 
 Although this metadata is optional *for Simplechart*, your CMS (e.g. WordPress) may require a title before saving the chart in the database. In this case, you may need to enter a post title directly in the CMS before saving the chart, if you have not already added a title in the Simplechart app.

--- a/app/utils/misc.js
+++ b/app/utils/misc.js
@@ -51,6 +51,22 @@ export function getObjArrayKey(obj, key, defaultValue = '') {
 }
 
 /**
+ * get value from key or default if not set or not a string,
+ * also works for arrays
+ *
+ * @param {Object} obj Basic object or array
+ * @param {String} key Key to look for
+ * @param {*} defaultValue Default to return if key is not set
+ */
+export function getObjArrayKeyStringOnly(obj, key, defaultValue = '') {
+  return obj &&
+    Object.prototype.hasOwnProperty.call(obj, key) &&
+    'string' === typeof obj[key] ?
+    obj[key] :
+    defaultValue;
+}
+
+/**
  * Capitalize the first char of a string, assumes first char is a letter
  */
 export function capitalize(input) {

--- a/docs/_includes/embed.html
+++ b/docs/_includes/embed.html
@@ -5,6 +5,7 @@
   data-placeholder='Waiting for chart data to be saved...'
 >
   <p class='simplechart-title'></p>
+  <p class='simplechart-subtitle'></p>
   <p class='simplechart-caption'></p>
   <div class='simplechart-chart'></div>
   <p class='simplechart-credit'></p>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   </head>
   <body>
     <div id='app'></div>
-    <script type="text/javascript" src="/static/vendor.058bffe.js"></script>
-    <script type="text/javascript" src="/static/app.058bffe.js"></script>
+    <script type="text/javascript" src="/static/vendor.js"></script>
+    <script type="text/javascript" src="/static/app.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,24 +1,25 @@
 <!DOCTYPE html>
 <html>
-  <head lang="en">
-    <meta charset="UTF-8">
-    <title>Simplechart</title>
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-        font-family: -apple-system, BlinkMacSystemFont,
-          "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
-          "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-      }
-      html, body, #app {
-        height: 100%;
-      }
-    </style>
+<head lang="en">
+  <meta charset="UTF-8">
+  <title>Simplechart</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: -apple-system, BlinkMacSystemFont,
+      "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
+      "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    }
+
+    html, body, #app {
+      height: 100%;
+    }
+  </style>
   </head>
   <body>
     <div id='app'></div>
-    <script src="/static/vendor.js"></script>
-    <script src="/static/app.js"></script>
+    <script type="text/javascript" src="vendor.4ae903a.js"></script>
+    <script type="text/javascript" src="app.4ae903a.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   </head>
   <body>
     <div id='app'></div>
-    <script type="text/javascript" src="vendor.4ae903a.js"></script>
-    <script type="text/javascript" src="app.4ae903a.js"></script>
+    <script type="text/javascript" src="/static/vendor.058bffe.js"></script>
+    <script type="text/javascript" src="/static/app.058bffe.js"></script>
   </body>
 </html>

--- a/mock-api/mockMetadata.js
+++ b/mock-api/mockMetadata.js
@@ -7,6 +7,7 @@ const titles = {
 function chartTypeMetadata(type) {
   return {
     title: titles[type],
+    subtitle: `Subtitle for ${titles[type]}`,
     caption: `Caption for ${titles[type]}`,
     source: `Data source for ${titles[type]}`,
   };

--- a/mock-api/sampleData1.json
+++ b/mock-api/sampleData1.json
@@ -3,6 +3,6 @@
   "data": {
     "data": "[{\"label\":\"One\",\"value\":29.7},{\"label\":\"Two\",\"value\":0},{\"label\":\"Three\",\"value\":32.8},{\"label\":\"Four\",\"value\":196.4},{\"label\":\"Five\",\"value\":0.1},{\"label\":\"Six\",\"value\":98},{\"label\":\"Seven\",\"value\":13.9},{\"label\":\"Eight\",\"value\":5.1}]",
     "options": "{\"type\":\"discreteBarChart\",\"height\":500}",
-    "metadata": "{\"title\":\"Sample Bart Chart\",\"caption\":\"An example of the NVD3 discreteBarChart\",\"credit\":\"Alley Interactive\"}"
+    "metadata": "{\"title\":\"Sample Bar Chart\",\"subtitle\":\"Sample Subtitle\",\"caption\":\"An example of the NVD3 discreteBarChart\",\"credit\":\"Alley Interactive\"}"
   }
 }

--- a/mock-api/sampleData2.json
+++ b/mock-api/sampleData2.json
@@ -3,6 +3,6 @@
   "data": {
     "data": "[{\"label\":\"One\",\"value\":29.7},{\"label\":\"Two\",\"value\":18.4},{\"label\":\"Three\",\"value\":15.1}]",
     "options": "{\"type\":\"pieChart\",\"height\":500}",
-    "metadata": "{\"title\":\"Sample Pie Chart\",\"caption\":\"An example of the NVD3 pieChart\",\"credit\":\"Alley Interactive\"}"
+    "metadata": "{\"title\":\"Sample Pie Chart\",\"subtitle\":\"Sample Subtitle\",\"caption\":\"An example of the NVD3 pieChart\",\"credit\":\"Alley Interactive\"}"
   }
 }

--- a/widget.hbs
+++ b/widget.hbs
@@ -25,6 +25,7 @@
         data-placeholder='Custom Placeholder Message'
     >
       <p class='simplechart-title'></p>
+      <p class='simplechart-subtitle'></p>
       <p class='simplechart-caption'></p>
       <div class='simplechart-chart'></div>
       <p class='simplechart-credit'></p>
@@ -37,6 +38,7 @@
         data-url='/api/lineChart'
     >
       <p class='simplechart-title'></p>
+      <p class='simplechart-subtitle'></p>
       <p class='simplechart-caption'></p>
       <div class='simplechart-chart'></div>
       <p class='simplechart-credit'></p>

--- a/widget.html
+++ b/widget.html
@@ -44,6 +44,6 @@
       <p class='simplechart-credit'></p>
     </figure>
 
-    <script type="text/javascript" src="widget.4ae903a.js"></script>
+    <script type="text/javascript" src="widget.058bffe.js"></script>
   </body>
 </html>

--- a/widget.html
+++ b/widget.html
@@ -44,6 +44,6 @@
       <p class='simplechart-credit'></p>
     </figure>
 
-    <script type="text/javascript" src="widget.058bffe.js"></script>
+    <script type="text/javascript" src="/static/widget.js"></script>
   </body>
 </html>

--- a/widget.html
+++ b/widget.html
@@ -6,25 +6,26 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/nvd3/1.8.1/nv.d3.min.css"/>
     <link rel="stylesheet" href="http://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">
     <style>
-        header > h1 {
-            text-align: center;
-            font-family: sans-serif;
-        }
+      header > h1 {
+        text-align: center;
+        font-family: sans-serif;
+      }
     </style>
   </head>
   <body>
     <header>
-        <h1>Simplechart-React widget</h1>
+      <h1>Simplechart-React widget</h1>
     </header>
 
     <h2>Widget 1</h2>
     <figure
-      id='widget1'
-      class='simplechart-widget'
-      data-url='/api/pieChart'
-      data-placeholder='Custom Placeholder Message'
+        id='widget1'
+        class='simplechart-widget'
+        data-url='/api/pieChart'
+        data-placeholder='Custom Placeholder Message'
     >
       <p class='simplechart-title'></p>
+      <p class='simplechart-subtitle'></p>
       <p class='simplechart-caption'></p>
       <div class='simplechart-chart'></div>
       <p class='simplechart-credit'></p>
@@ -32,16 +33,17 @@
 
     <h2>Widget 2</h2>
     <figure
-      id='widget2'
-      class='simplechart-widget'
-      data-url='/api/lineChart'
+        id='widget2'
+        class='simplechart-widget'
+        data-url='/api/lineChart'
     >
       <p class='simplechart-title'></p>
+      <p class='simplechart-subtitle'></p>
       <p class='simplechart-caption'></p>
       <div class='simplechart-chart'></div>
       <p class='simplechart-credit'></p>
     </figure>
 
-    <script src="/static/widget.js"></script>
+    <script type="text/javascript" src="widget.4ae903a.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This PR adds a subtitle to the available metadata for a chart. The subtitle will be disabled by default unless the app is fed a truthy default chartMetaData value for it in the postMessage. If the value is a truthy non-string, it will show a blank subtitle field; if it is a string, it will show a default subtitle as it does when a default is provided for the other metadata.