### PR TITLE
SC-123 harmonize subtitle checks to avoid edge case scenarios 

### DIFF
--- a/app/components/DataInput/ChartTitle/index.js
+++ b/app/components/DataInput/ChartTitle/index.js
@@ -19,12 +19,21 @@ class ChartTitle extends Component {
     this.setState({ title: nextProps.metadata.title || '' });
   }
 
-  handleInput = (fieldProps, value) => ({
-    title: value,
-    caption: this.props.metadata.caption || '',
-    credit: this.props.metadata.credit || '',
-    subtitle: this.props.metadata.subtitle || false,
-  });
+  handleInput = (fieldProps, value) => {
+    let subtitle = '';
+    if ('undefined' !== typeof this.props.metadata.subtitle &&
+      ('' === this.props.metadata.subtitle || this.props.metadata.subtitle)) {
+      subtitle = this.props.metadata.subtitle;
+    } else {
+      subtitle = false;
+    }
+    return ({
+      title: value,
+      caption: this.props.metadata.caption || '',
+      credit: this.props.metadata.credit || '',
+      subtitle,
+    });
+  };
 
   render() {
     return (


### PR DESCRIPTION
This commit changes a check running on the ChartTitle component to determine whether or not a subtitle is set. Since the logic was different from the one in the Metadata component, with the new changes implemented in the wordpress-plugin repository's sister PR to this one (https://github.com/alleyinteractive/wordpress-simplechart/pull/92/files) it was causing some edge case issues wherein if a user entered something into the title field on the first tab, the subtitle field would sometimes disable on the third.