### PR TITLE
BR-1715 Help doc for breakpoints

### DIFF
--- a/app/components/ChartLayout/index.js
+++ b/app/components/ChartLayout/index.js
@@ -10,6 +10,7 @@ import {
 import actionTrigger from '../../actions';
 import AccordionBlock from '../Layout/AccordionBlock';
 import DispatchField from '../lib/DispatchField';
+import HelpTrigger from '../lib/HelpTrigger';
 import { defaultBreakpoint } from '../../constants/chartTypes';
 
 class ChartLayout extends Component {
@@ -207,11 +208,14 @@ class ChartLayout extends Component {
     return (
       <div>
         {this.state.values.map(this.renderBreakpoint)}
-        <Button
-          theme="success"
-          big
-          onClick={this.addBreakpoint}
-        >Add Breakpoint</Button>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <Button
+            theme="success"
+            big
+            onClick={this.addBreakpoint}
+          >Add Breakpoint</Button>
+          <HelpTrigger style={{ marginLeft: '12px' }} docName="breakpoints" />
+        </div>
       </div>
     );
   }

--- a/app/pages/help/breakpoints.md
+++ b/app/pages/help/breakpoints.md
@@ -4,22 +4,22 @@ Simplechart is designed to draw charts with a fixed height and variable width. S
 
 The default breakpoint sets a height of 400 pixels at all screen widths. At that height, a chart might look like this on a desktop monitor:
 
-![400px chart height on desktop](../../img/breakpoints/embed_desktop_400.png)
+![400px chart height on desktop](http://simplechart.io/lib/images/help-docs/breakpoints/embed_desktop_400.png)
 
 And this on a mobile device:
 
 <p style="max-width: 225px">
-![400px chart height on mobile](../../img/breakpoints/embed_mobile_400.png)
+![400px chart height on mobile](http://simplechart.io/lib/images/help-docs/breakpoints/embed_mobile_400.png)
 </p>
 
 If you wanted the chart to take up less of the screen on mobile devices, here's how you would change the height to 250 pixels on devices up to 400 pixels wide:
 
-![Adding a breakpoint](../../img/breakpoints/adding_breakpoint.gif)
+![Adding a breakpoint](http://simplechart.io/lib/images/help-docs/breakpoints/adding_breakpoint.gif)
 
 Now, the chart looks like this:
 
 <p style="max-width: 225px">
-![250px chart height on mobile](../../img/breakpoints/embed_mobile_250.png)
+![250px chart height on mobile](http://simplechart.io/lib/images/help-docs/breakpoints/embed_mobile_250.png)
 </p>
 
 We did this by:

--- a/app/pages/help/breakpoints.md
+++ b/app/pages/help/breakpoints.md
@@ -1,0 +1,34 @@
+## Using Breakpoints
+
+Simplechart is designed to draw charts with a fixed height and variable width. Sometimes, this requires special handling for different screen sizes, e.g. desktop vs. mobile. The **Breakpoints** feature allows you specify the chart's height depending on the available width of the screen or page design.
+
+The default breakpoint sets a height of 400 pixels at all screen widths. At that height, a chart might look like this on a desktop monitor:
+
+![400px chart height on desktop](../../img/breakpoints/embed_desktop_400.png)
+
+And this on a mobile device:
+
+<p style="max-width: 225px">
+![400px chart height on mobile](../../img/breakpoints/embed_mobile_400.png)
+</p>
+
+If you wanted the chart to take up less of the screen on mobile devices, here's how you would change the height to 250 pixels on devices up to 400 pixels wide:
+
+![Adding a breakpoint](../../img/breakpoints/adding_breakpoint.gif)
+
+Now, the chart looks like this:
+
+<p style="max-width: 225px">
+![250px chart height on mobile](../../img/breakpoints/embed_mobile_250.png)
+</p>
+
+We did this by:
+
+1. Clicking the green "Add Breakpoint" button
+1. Setting the max width to `400`
+1. Setting the height to `250`
+
+After those steps, the chart has two breakpoints:
+
+* Regardless of screen width, **Breakpoint 1** sets the _height_ to 400 pixels.
+* On screens up to 400 pixels wide, **Breakpoint 2** supersedes Breakpoint 1 and reduces the height to 250 pixels.

--- a/app/pages/help/breakpoints.md
+++ b/app/pages/help/breakpoints.md
@@ -1,6 +1,6 @@
 ## Using Breakpoints
 
-Simplechart is designed to draw charts with a fixed height and variable width. Sometimes, this requires special handling for different screen sizes, e.g. desktop vs. mobile. The **Breakpoints** feature allows you specify the chart's height depending on the available width of the screen or page design.
+Simplechart is designed to draw charts with a fixed height and variable width. Sometimes, this requires special handling for different screen sizes, e.g. desktop vs. mobile. The **Breakpoints** feature allows you to specify the chart's height depending on the available width of the screen or page design.
 
 The default breakpoint sets a height of 400 pixels at all screen widths. At that height, a chart might look like this on a desktop monitor:
 

--- a/app/pages/help/breakpoints.md
+++ b/app/pages/help/breakpoints.md
@@ -9,7 +9,9 @@ The default breakpoint sets a height of 400 pixels at all screen widths. At that
 And this on a mobile device:
 
 <p style="max-width: 225px">
+
 ![400px chart height on mobile](http://simplechart.io/lib/images/help-docs/breakpoints/embed_mobile_400.png)
+
 </p>
 
 If you wanted the chart to take up less of the screen on mobile devices, here's how you would change the height to 250 pixels on devices up to 400 pixels wide:
@@ -19,7 +21,9 @@ If you wanted the chart to take up less of the screen on mobile devices, here's 
 Now, the chart looks like this:
 
 <p style="max-width: 225px">
+
 ![250px chart height on mobile](http://simplechart.io/lib/images/help-docs/breakpoints/embed_mobile_250.png)
+
 </p>
 
 We did this by:

--- a/app/pages/help/breakpoints.md
+++ b/app/pages/help/breakpoints.md
@@ -8,11 +8,12 @@ The default breakpoint sets a height of 400 pixels at all screen widths. At that
 
 And this on a mobile device:
 
-<p style="max-width: 225px">
+<img
+  alt="400px chart height on mobile"
+  src="http://simplechart.io/lib/images/help-docs/breakpoints/embed_mobile_400.png"
+  style="max-width: 225px !important"
+/>
 
-![400px chart height on mobile](http://simplechart.io/lib/images/help-docs/breakpoints/embed_mobile_400.png)
-
-</p>
 
 If you wanted the chart to take up less of the screen on mobile devices, here's how you would change the height to 250 pixels on devices up to 400 pixels wide:
 
@@ -20,11 +21,11 @@ If you wanted the chart to take up less of the screen on mobile devices, here's 
 
 Now, the chart looks like this:
 
-<p style="max-width: 225px">
-
-![250px chart height on mobile](http://simplechart.io/lib/images/help-docs/breakpoints/embed_mobile_250.png)
-
-</p>
+<img
+  alt="250px chart height on mobile"
+  src="http://simplechart.io/lib/images/help-docs/breakpoints/embed_mobile_250.png"
+  style="max-width: 225px !important"
+/>
 
 We did this by:
 

--- a/app/pages/help/index.js
+++ b/app/pages/help/index.js
@@ -1,9 +1,11 @@
+import breakpoints from './breakpoints.md';
 import chartMetadata from './chartMetadata.md';
 import dataInput from './dataInput.md';
 import dateFormatter from './dateFormatter.md';
 import googleSheets from './googleSheets.md';
 
 export default {
+  breakpoints,
   chartMetadata,
   dataInput,
   dateFormatter,

--- a/dev-webpack.config.js
+++ b/dev-webpack.config.js
@@ -66,7 +66,7 @@ module.exports = {
         ],
       },
       {
-        test: /\.(png|jpg)$/,
+        test: /\.(png|jpg|gif)$/,
         use: [
           {
             loader: 'url-loader',

--- a/prod-webpack.config.js
+++ b/prod-webpack.config.js
@@ -92,7 +92,7 @@ module.exports = {
         ],
       },
       {
-        test: /\.(png|jpg)$/,
+        test: /\.(png|jpg|gif)$/,
         use: [
           {
             loader: 'url-loader',


### PR DESCRIPTION
See https://github.com/alleyinteractive/simplechart/blob/BR-1715-breakpoints-help/app/pages/help/breakpoints.md

(not sure why the "mobile" images aren't being restricted to 225px wide; the style attribute of the inline `<img>` tag works fine in the app)